### PR TITLE
Support additional print flags in PF_Loc_Print()

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -119,6 +119,7 @@ q_noreturn q_printf(2, 3);
 #define PRINT_CHAT          3       // chat messages    
 #define PRINT_TYPEWRITER    4       // centerprint but typed out one char at a time
 #define PRINT_CENTER        5       // centerprint without a separate function (loc variants only)
+#define PRINT_TTS           6       // PRINT_HIGH but will speak for players with narration on
 #define PRINT_BROADCAST     BIT(3)  // Bitflag, add to message to broadcast print to all clients.
 #define PRINT_NO_NOTIFY     BIT(4)  // Bitflag, don't put on notify
 

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -119,7 +119,8 @@ q_noreturn q_printf(2, 3);
 #define PRINT_CHAT          3       // chat messages    
 #define PRINT_TYPEWRITER    4       // centerprint but typed out one char at a time
 #define PRINT_CENTER        5       // centerprint without a separate function (loc variants only)
-#define PRINT_BROADCAST     8       // Bitflag, add to message to broadcast print to all clients.
+#define PRINT_BROADCAST     BIT(3)  // Bitflag, add to message to broadcast print to all clients.
+#define PRINT_NO_NOTIFY     BIT(4)  // Bitflag, don't put on notify
 
 
 // destination class for gi.multicast()

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -786,7 +786,8 @@ static void PF_Loc_Print(edict_t* ent, print_type_t level, const char* base, con
     if (level & PRINT_BROADCAST) {
         print_type_t broadcast_level = level & ~(PRINT_BROADCAST | PRINT_NO_NOTIFY);
         // restrict to print levels support by by svc_print
-        broadcast_level = min(broadcast_level, PRINT_CHAT);
+        if (broadcast_level > PRINT_CHAT && broadcast_level != PRINT_TTS)
+            broadcast_level = PRINT_CHAT;
         PF_Broadcast_Print(broadcast_level, string);
     } else {
         level &= ~PRINT_NO_NOTIFY; // TODO implement

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -782,7 +782,19 @@ static void PF_Loc_Print(edict_t* ent, print_type_t level, const char* base, con
 
     char string[MAX_STRING_CHARS];
     Loc_Localize(base, true, args, num_args, string, sizeof(string));
-    PF_Client_Print(ent, level, string);
+
+    if (level & PRINT_BROADCAST) {
+        print_type_t broadcast_level = level & ~(PRINT_BROADCAST | PRINT_NO_NOTIFY);
+        // restrict to print levels support by by svc_print
+        broadcast_level = min(broadcast_level, PRINT_CHAT);
+        PF_Broadcast_Print(broadcast_level, string);
+    } else {
+        level &= ~PRINT_NO_NOTIFY; // TODO implement
+        if (level == PRINT_CENTER || level == PRINT_TYPEWRITER)
+            PF_Center_Print(ent, string);
+        else
+            PF_Client_Print(ent, level, string);
+    }
 }
 
 #if USE_REF


### PR DESCRIPTION
So e.g. `PRINT_CENTER` appears as a centerprint.

Still ignores `PRINT_NO_NOTIFY`.