### PR TITLE
Improve compatibility to "classic" Q2PRO servers

### DIFF
--- a/inc/common/game3_shared.h
+++ b/inc/common/game3_shared.h
@@ -70,19 +70,59 @@ static inline game3_pmtype_t pmtype_to_game3(pmtype_t pmtype)
     return (game3_pmtype_t)pmtype;
 }
 
-/* TODO: These are pmflags as defined by Q2PRO;
- * need translation to "new" values */
-#if 0
 // pmove->pm_flags
-#define PMF_DUCKED          BIT(0)
-#define PMF_JUMP_HELD       BIT(1)
-#define PMF_ON_GROUND       BIT(2)
-#define PMF_TIME_WATERJUMP  BIT(3)      // pm_time is waterjump
-#define PMF_TIME_LAND       BIT(4)      // pm_time is time before rejump
-#define PMF_TIME_TELEPORT   BIT(5)      // pm_time is non-moving time
-#define PMF_NO_PREDICTION   BIT(6)      // temporarily disables prediction (used for grappling hook)
-#define PMF_TELEPORT_BIT    BIT(7)      // used by Q2PRO (non-extended servers)
-#endif
+#define G3PMF_DUCKED          BIT(0)
+#define G3PMF_JUMP_HELD       BIT(1)
+#define G3PMF_ON_GROUND       BIT(2)
+#define G3PMF_TIME_WATERJUMP  BIT(3)      // pm_time is waterjump
+#define G3PMF_TIME_LAND       BIT(4)      // pm_time is time before rejump
+#define G3PMF_TIME_TELEPORT   BIT(5)      // pm_time is non-moving time
+#define G3PMF_NO_PREDICTION   BIT(6)      // temporarily disables prediction (used for grappling hook)
+#define G3PMF_TELEPORT_BIT    BIT(7)      // used by Q2PRO (non-extended servers)
+
+static inline pmflags_t pmflags_from_game3(byte pmflags)
+{
+    pmflags_t new_pmflags = 0;
+    if(pmflags & G3PMF_DUCKED)
+        new_pmflags |= PMF_DUCKED;
+    if(pmflags & G3PMF_JUMP_HELD)
+        new_pmflags |= PMF_JUMP_HELD;
+    if(pmflags & G3PMF_ON_GROUND)
+        new_pmflags |= PMF_ON_GROUND;
+    if(pmflags & G3PMF_TIME_WATERJUMP)
+        new_pmflags |= PMF_TIME_WATERJUMP;
+    if(pmflags & G3PMF_TIME_LAND)
+        new_pmflags |= PMF_TIME_LAND;
+    if(pmflags & G3PMF_TIME_TELEPORT)
+        new_pmflags |= PMF_TIME_TELEPORT;
+    if(pmflags & G3PMF_NO_PREDICTION)
+        new_pmflags |= PMF_NO_PREDICTION;
+    if(pmflags & G3PMF_TELEPORT_BIT)
+        new_pmflags |= PMF_TELEPORT_BIT;
+    return new_pmflags;
+}
+
+static inline byte pmflags_to_game3(pmflags_t pmflags)
+{
+    byte new_pmflags = 0;
+    if(pmflags & PMF_DUCKED)
+        new_pmflags |= G3PMF_DUCKED;
+    if(pmflags & PMF_JUMP_HELD)
+        new_pmflags |= G3PMF_JUMP_HELD;
+    if(pmflags & PMF_ON_GROUND)
+        new_pmflags |= G3PMF_ON_GROUND;
+    if(pmflags & PMF_TIME_WATERJUMP)
+        new_pmflags |= G3PMF_TIME_WATERJUMP;
+    if(pmflags & PMF_TIME_LAND)
+        new_pmflags |= G3PMF_TIME_LAND;
+    if(pmflags & PMF_TIME_TELEPORT)
+        new_pmflags |= G3PMF_TIME_TELEPORT;
+    if(pmflags & PMF_NO_PREDICTION)
+        new_pmflags |= G3PMF_NO_PREDICTION;
+    if(pmflags & PMF_TELEPORT_BIT)
+        new_pmflags |= G3PMF_TELEPORT_BIT;
+    return new_pmflags;
+}
 
 typedef struct {
     game3_pmtype_t pm_type;

--- a/inc/common/game3_shared.h
+++ b/inc/common/game3_shared.h
@@ -20,21 +20,59 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 typedef struct game3_edict_s game3_edict_t;
 
-/* TODO: These are pmtype, pmflags as defined by Q2PRO;
- * need translation to "new" values */
-#if 0
 // pmove_state_t is the information necessary for client side movement
 // prediction
 typedef enum {
     // can accelerate and turn
-    PM_NORMAL,
-    PM_SPECTATOR,
+    G3PM_NORMAL,
+    G3PM_SPECTATOR,
     // no acceleration or turning
-    PM_DEAD,
-    PM_GIB,     // different bounding box
-    PM_FREEZE
-} pmtype_t;
+    G3PM_DEAD,
+    G3PM_GIB,     // different bounding box
+    G3PM_FREEZE
+} game3_pmtype_t;
 
+static inline pmtype_t pmtype_from_game3(game3_pmtype_t pmtype)
+{
+    switch(pmtype)
+    {
+    case G3PM_NORMAL:
+        return PM_NORMAL;
+    case G3PM_SPECTATOR:
+        return PM_SPECTATOR;
+    case G3PM_DEAD:
+        return PM_DEAD;
+    case G3PM_GIB:
+        return PM_GIB;
+    case G3PM_FREEZE:
+        return PM_FREEZE;
+    }
+    return (pmtype_t)pmtype;
+}
+
+static inline game3_pmtype_t pmtype_to_game3(pmtype_t pmtype)
+{
+    switch(pmtype)
+    {
+    case PM_NORMAL:
+        return G3PM_NORMAL;
+    case PM_GRAPPLE:
+    case PM_NOCLIP:
+    case PM_SPECTATOR:
+        return G3PM_SPECTATOR;
+    case PM_DEAD:
+        return G3PM_DEAD;
+    case PM_GIB:
+        return G3PM_GIB;
+    case PM_FREEZE:
+        return G3PM_FREEZE;
+    }
+    return (game3_pmtype_t)pmtype;
+}
+
+/* TODO: These are pmflags as defined by Q2PRO;
+ * need translation to "new" values */
+#if 0
 // pmove->pm_flags
 #define PMF_DUCKED          BIT(0)
 #define PMF_JUMP_HELD       BIT(1)
@@ -47,7 +85,7 @@ typedef enum {
 #endif
 
 typedef struct {
-    pmtype_t    pm_type;
+    game3_pmtype_t pm_type;
 
     short       origin[3];      // 12.3
     short       velocity[3];    // 12.3

--- a/inc/common/game3_shared.h
+++ b/inc/common/game3_shared.h
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+typedef struct game3_edict_s game3_edict_t;
+
+/* TODO: These are pmtype, pmflags as defined by Q2PRO;
+ * need translation to "new" values */
+#if 0
+// pmove_state_t is the information necessary for client side movement
+// prediction
+typedef enum {
+    // can accelerate and turn
+    PM_NORMAL,
+    PM_SPECTATOR,
+    // no acceleration or turning
+    PM_DEAD,
+    PM_GIB,     // different bounding box
+    PM_FREEZE
+} pmtype_t;
+
+// pmove->pm_flags
+#define PMF_DUCKED          BIT(0)
+#define PMF_JUMP_HELD       BIT(1)
+#define PMF_ON_GROUND       BIT(2)
+#define PMF_TIME_WATERJUMP  BIT(3)      // pm_time is waterjump
+#define PMF_TIME_LAND       BIT(4)      // pm_time is time before rejump
+#define PMF_TIME_TELEPORT   BIT(5)      // pm_time is non-moving time
+#define PMF_NO_PREDICTION   BIT(6)      // temporarily disables prediction (used for grappling hook)
+#define PMF_TELEPORT_BIT    BIT(7)      // used by Q2PRO (non-extended servers)
+#endif
+
+typedef struct {
+    pmtype_t    pm_type;
+
+    short       origin[3];      // 12.3
+    short       velocity[3];    // 12.3
+    byte        pm_flags;       // ducked, jump_held, etc
+    byte        pm_time;        // each unit = 8 ms
+    short       gravity;
+    short       delta_angles[3];    // add to command angles to get view direction
+                                    // changed by spawns, rotating objects, and teleporters
+} game3_pmove_state_t;
+
+typedef struct {
+    qboolean    allsolid;   // if true, plane is not valid
+    qboolean    startsolid; // if true, the initial point was in a solid area
+    float       fraction;   // time completed, 1.0 = didn't hit anything
+    vec3_t      endpos;     // final position
+    cplane_t    plane;      // surface normal at impact
+    csurface_t  *surface;   // surface hit
+    int         contents;   // contents on other side of surface hit
+    game3_edict_t  *ent;    // not set by CM_*() functions
+} game3_trace_t;
+
+typedef struct game3_usercmd_s {
+    byte    msec;
+    byte    buttons;
+    short   angles[3];
+    short   forwardmove, sidemove, upmove;
+    byte    impulse;        // remove?
+    byte    lightlevel;     // light level the player is standing on
+} game3_usercmd_t;
+
+typedef struct {
+    // state (in / out)
+    game3_pmove_state_t s;
+
+    // command (in)
+    game3_usercmd_t cmd;
+    qboolean        snapinitial;    // if s has been changed outside pmove
+
+    // results (out)
+    int         numtouch;
+    game3_edict_t  *touchents[MAXTOUCH];
+
+    vec3_t      viewangles;         // clamped
+    float       viewheight;
+
+    vec3_t      mins, maxs;         // bounding box size
+
+    game3_edict_t  *groundentity;
+    int         watertype;
+    int         waterlevel;
+
+    // callbacks to test the world
+    game3_trace_t (* q_gameabi trace)(const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end);
+    int         (*pointcontents)(const vec3_t point);
+} game3_pmove_t;

--- a/inc/common/msg.h
+++ b/inc/common/msg.h
@@ -77,10 +77,11 @@ typedef enum {
     MSG_PS_IGNORE_DELTAANGLES   = BIT(4),   // ignore delta_angles
     MSG_PS_IGNORE_PREDICTION    = BIT(5),   // mutually exclusive with IGNORE_VIEWANGLES
     MSG_PS_EXTENSIONS           = BIT(6),   // enable protocol extensions
-    MSG_PS_FLOAT_COORDS         = BIT(7),   // floating point coordinates
-    MSG_PS_NEW_STATS            = BIT(8),   // increased stats numbers
-    MSG_PS_FORCE                = BIT(9),   // send even if unchanged (MVD stream only)
-    MSG_PS_REMOVE               = BIT(10),  // player is removed (MVD stream only)
+    MSG_PS_RERELEASE            = BIT(7),   // rerelease extensions: floating point coordinates,
+                                            // increased stats numbers,
+                                            // wider pm_time and pm_flags
+    MSG_PS_FORCE                = BIT(8),   // send even if unchanged (MVD stream only)
+    MSG_PS_REMOVE               = BIT(9),  // player is removed (MVD stream only)
 } msgPsFlags_t;
 
 typedef enum {
@@ -92,7 +93,7 @@ typedef enum {
     MSG_ES_BEAMORIGIN   = BIT(5),   // client has RF_BEAM old_origin fix
     MSG_ES_SHORTANGLES  = BIT(6),   // higher precision angles encoding
     MSG_ES_EXTENSIONS   = BIT(7),   // enable protocol extensions
-    MSG_ES_FLOAT_COORDS = BIT(8),   // floating point coordinates
+    MSG_ES_RERELEASE    = BIT(8),   // rerelease extensions: floating point coordinates
     MSG_ES_REMOVE       = BIT(9),   // entity is removed (MVD stream only)
 } msgEsFlags_t;
 

--- a/inc/common/pmove.h
+++ b/inc/common/pmove.h
@@ -44,7 +44,7 @@ typedef struct {
     float       flyfriction;
 } pmoveParams_t;
 
-void Pmove(pmove_t *pmove, pmoveParams_t *params);
+void Pmove(pmove_t *pmove, const pmoveParams_t *params);
 
 void PmoveInit(pmoveParams_t *pmp);
 void PmoveEnableQW(pmoveParams_t *pmp);

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ common_src = [
   'inc/common/field.h',
   'inc/common/fifo.h',
   'inc/common/files.h',
+  'inc/common/game3_shared.h',
   'inc/common/gamedll.h',
   'inc/common/hash_map.h',
   'inc/common/intreadwrite.h',

--- a/src/client/cgame.c
+++ b/src/client/cgame.c
@@ -98,10 +98,10 @@ static void CG_Print(const char *msg)
 
 static const char *CG_get_configstring(int index)
 {
-    if (index < 0 || index >= cs_remap_rerelease.end)
+    if (index < 0 || index >= cl.csr.end)
         Com_Error(ERR_DROP, "%s: bad index: %d", __func__, index);
 
-    return cl.configstrings[remap_cs_index(index, &cs_remap_rerelease, &cl.csr)];
+    return cl.configstrings[index];
 }
 
 static void CG_Com_Error(const char *message)

--- a/src/client/cgame.c
+++ b/src/client/cgame.c
@@ -447,9 +447,10 @@ void CG_Load(const char* new_game)
         }
 
         if(!entry) {
-            // FIXME: Should probably be a fatal error
-            Com_Printf("cgame functions not available, falling back to built-in cgame\n");
-            entry = GetClassicCGameAPI;
+            Com_Error(ERR_DROP, "cgame functions not available");
+            cgame = NULL;
+            Z_Freep(&current_game);
+            current_protocol = 0;
         }
 
         cgame = entry(&cgame_imports);

--- a/src/client/cgame.c
+++ b/src/client/cgame.c
@@ -66,6 +66,11 @@ static void CGX_SetColor(uint32_t color)
     R_SetColor(new_color.u32);
 }
 
+static const pmoveParams_t* CGX_GetPmoveParams(void)
+{
+    return &cl.pmp;
+}
+
 static cgame_q2pro_extended_support_ext_t cgame_q2pro_extended_support = {
     .api_version = 1,
 
@@ -73,6 +78,7 @@ static cgame_q2pro_extended_support_ext_t cgame_q2pro_extended_support = {
     .ClearColor = CGX_ClearColor,
     .SetAlpha = CGX_SetAlpha,
     .SetColor = CGX_SetColor,
+    .GetPmoveParams = CGX_GetPmoveParams,
 };
 
 void CG_Init(void)

--- a/src/client/cgame.c
+++ b/src/client/cgame.c
@@ -454,6 +454,7 @@ void CG_Load(const char* new_game)
         }
 
         cgame = entry(&cgame_imports);
+        Z_Freep(&current_game);
         current_game = Z_CopyString(new_game);
         current_protocol = cls.serverProtocol;
     }

--- a/src/client/cgame_classic.c
+++ b/src/client/cgame_classic.c
@@ -836,6 +836,15 @@ static void CGC_TouchPics(void)
     cgi.Draw_RegisterPic(inven_pic);
 }
 
+static void CGC_Pmove(pmove_t *pmove)
+{
+    Pmove(pmove, cgix.GetPmoveParams());
+
+    /* viewheight is now added to the viewoffset; this didn't happen in vanilla,
+     * so clear out the viewheight */
+    pmove->s.viewheight = 0;
+}
+
 static void CGC_ParseCenterPrint(const char *str, int isplit, bool instant)
 {
     const char  *s;
@@ -876,6 +885,8 @@ cgame_export_t cgame_classic = {
 
     .DrawHUD = CGC_DrawHUD,
     .TouchPics = CGC_TouchPics,
+
+    .Pmove = CGC_Pmove,
 
     .ParseCenterPrint = CGC_ParseCenterPrint,
     .ClearCenterprint = CGC_ClearCenterprint,

--- a/src/client/cgame_classic.c
+++ b/src/client/cgame_classic.c
@@ -825,6 +825,17 @@ static void CGC_DrawHUD (int32_t isplit, const cg_server_data_t *data, vrect_t h
     SCR_DrawCenterString(hud_vrect);
 }
 
+static void CGC_TouchPics(void)
+{
+    for (int i = 0; i < 2; i++) {
+        for (int j = 0; j < STAT_PICS; j++)
+            cgi.Draw_RegisterPic(sb_nums[i][j]);
+    }
+
+    cgi.Draw_RegisterPic(field_pic);
+    cgi.Draw_RegisterPic(inven_pic);
+}
+
 static void CGC_ParseCenterPrint(const char *str, int isplit, bool instant)
 {
     const char  *s;
@@ -864,6 +875,7 @@ cgame_export_t cgame_classic = {
     .Shutdown = CGC_Shutdown,
 
     .DrawHUD = CGC_DrawHUD,
+    .TouchPics = CGC_TouchPics,
 
     .ParseCenterPrint = CGC_ParseCenterPrint,
     .ClearCenterprint = CGC_ClearCenterprint,

--- a/src/client/cgame_classic.h
+++ b/src/client/cgame_classic.h
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "shared/game.h"
+#include "common/pmove.h"
 
 // Extension structure to give classic cgame some extended features
 typedef struct {
@@ -29,6 +30,9 @@ typedef struct {
     void (*ClearColor)(void);
     void (*SetAlpha)(float alpha);
     void (*SetColor)(uint32_t color);
+
+    // Return pmove parameters for server
+    const pmoveParams_t *(*GetPmoveParams)(void);
 } cgame_q2pro_extended_support_ext_t;
 
 // Extension name

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -706,8 +706,8 @@ static void CL_ParseServerData(void)
         // FIXME: These shouldn't really matter, as pmove should be handled by the game/client library...
         read_q2pro_protocol_flags();
         cl.csr = cs_remap_rerelease;
-        cl.psFlags |= MSG_PS_FLOAT_COORDS | MSG_PS_NEW_STATS;
-        cl.esFlags |= MSG_ES_FLOAT_COORDS;
+        cl.psFlags |= MSG_PS_RERELEASE;
+        cl.esFlags |= MSG_ES_RERELEASE;
         int32_t rate = MSG_ReadByte();
         cl.sv_frametime = (1.0f / rate) * 1000;
         cl.sv_frametime_inv = 1.0f / cl.sv_frametime;
@@ -768,7 +768,7 @@ snd_params_t    snd;
 
 static void CL_ParseTEntPacket(void)
 {
-    bool float_coords = cl.esFlags & MSG_ES_FLOAT_COORDS;
+    bool float_coords = cl.esFlags & MSG_ES_RERELEASE;
     te.type = MSG_ReadByte();
 
     switch (te.type) {
@@ -969,7 +969,7 @@ static void CL_ParseStartSoundPacket(void)
 
     // positioned in space
     if (flags & SND_POS)
-        MSG_ReadPos(snd.pos, cl.esFlags & MSG_ES_FLOAT_COORDS);
+        MSG_ReadPos(snd.pos, cl.esFlags & MSG_ES_RERELEASE);
 
     snd.flags = flags;
 
@@ -1377,7 +1377,7 @@ static void CL_ParseHelpPath(void)
 {
     bool first_entry = !!MSG_ReadByte();
     vec3_t pos;
-    MSG_ReadPos(pos, cl.esFlags & MSG_ES_FLOAT_COORDS);
+    MSG_ReadPos(pos, cl.esFlags & MSG_ES_RERELEASE);
     vec3_t dir;
     MSG_ReadDir(dir);
 
@@ -1401,7 +1401,7 @@ static void CL_ParsePOI(void)
     // be used on reliable messages.
     int time = MSG_ReadShort();
     vec3_t p;
-    MSG_ReadPos(p, cl.esFlags & MSG_ES_FLOAT_COORDS);
+    MSG_ReadPos(p, cl.esFlags & MSG_ES_RERELEASE);
     int image = MSG_ReadShort();
     int color = MSG_ReadByte();
     int flags = MSG_ReadByte();

--- a/src/common/msg.c
+++ b/src/common/msg.c
@@ -1115,7 +1115,7 @@ int MSG_WriteDeltaPlayerstate_Enhanced(const player_packed_t    *from,
 
     if (!(flags & MSG_PS_IGNORE_BLEND)) {
         if (!Vector4Compare(from->screen_blend, to->screen_blend) ||
-            ((flags & MSG_PS_EXTENSIONS) && !Vector4Compare(from->damage_blend, to->damage_blend)))
+            ((flags & MSG_PS_RERELEASE) && !Vector4Compare(from->damage_blend, to->damage_blend)))
             pflags |= PS_BLEND;
     } else {
         // save previous state
@@ -1277,7 +1277,7 @@ int MSG_WriteDeltaPlayerstate_Enhanced(const player_packed_t    *from,
     }
 
     if (pflags & PS_BLEND) {
-        if (flags & MSG_PS_EXTENSIONS) {
+        if (flags & MSG_PS_RERELEASE) {
             int blend_bits = 0;
             
             if (from->screen_blend[0] != to->screen_blend[0]) blend_bits |= BLENDBITS_SCREEN_R;
@@ -2302,7 +2302,7 @@ void MSG_ParseDeltaPlayerstate_Enhanced(const player_state_t    *from,
     }
 
     if (flags & PS_BLEND) {
-        if (psflags & MSG_PS_EXTENSIONS) {
+        if (psflags & MSG_PS_RERELEASE) {
             int blend_bits = MSG_ReadByte();
             
             if (blend_bits & BLENDBITS_SCREEN_R) to->screen_blend[0] = MSG_ReadByte() / 255.f;
@@ -2445,7 +2445,7 @@ void MSG_ParseDeltaPlayerstate_Packet(const player_state_t  *from,
         to->screen_blend[2] = MSG_ReadByte() / 255.0f;
         to->screen_blend[3] = MSG_ReadByte() / 255.0f;
 
-        if (psflags & MSG_PS_EXTENSIONS) {
+        if (psflags & MSG_PS_RERELEASE) {
             to->damage_blend[0] = MSG_ReadByte() / 255.0f;
             to->damage_blend[1] = MSG_ReadByte() / 255.0f;
             to->damage_blend[2] = MSG_ReadByte() / 255.0f;

--- a/src/common/pmove.c
+++ b/src/common/pmove.c
@@ -1037,7 +1037,7 @@ void Pmove(pmove_t *pmove, pmoveParams_t *params)
     pm->watertype = 0;
     pm->waterlevel = 0;
 
-    int contentmask = /*pm->player->health > 0 ?*/ MASK_PLAYERSOLID /*: MASK_DEADSOLID*/; // FIXME
+    int contentmask = pm->s.pm_type < PM_SPECTATOR ? MASK_PLAYERSOLID : MASK_DEADSOLID;
 
     // clear all pmove local vars
     memset(&pml, 0, sizeof(pml));

--- a/src/common/pmove.c
+++ b/src/common/pmove.c
@@ -40,7 +40,7 @@ typedef struct {
 static pmove_t      *pm;
 static pml_t        pml;
 
-static pmoveParams_t    *pmp;
+static const pmoveParams_t    *pmp;
 
 // movement parameters
 static const float  pm_stopspeed = 100;
@@ -1024,7 +1024,7 @@ Pmove
 Can be called by either the server or the client
 ================
 */
-void Pmove(pmove_t *pmove, pmoveParams_t *params)
+void Pmove(pmove_t *pmove, const pmoveParams_t *params)
 {
     pm = pmove;
     pmp = params;

--- a/src/server/entities.c
+++ b/src/server/entities.c
@@ -279,7 +279,7 @@ void SV_WriteFrameToClient_Enhanced(client_t *client)
     }
     suppressed = client->frameflags;
     psFlags |= MSG_PS_EXTENSIONS;
-    psFlags |= MSG_PS_FLOAT_COORDS | MSG_PS_NEW_STATS;
+    psFlags |= MSG_PS_RERELEASE;
 
     // delta encode the playerstate
     extraflags = MSG_WriteDeltaPlayerstate_Enhanced(oldstate, &frame->ps, psFlags);

--- a/src/server/game3_proxy/game3.h
+++ b/src/server/game3_proxy/game3.h
@@ -42,46 +42,6 @@ typedef struct game3_entity_state_s {
                             // are automatically cleared each frame
 } game3_entity_state_t;
 
-typedef struct game3_edict_s game3_edict_t;
-
-/* TODO: These are pmtype, pmflags as defined by Q2PRO;
- * need translation to "new" values */
-#if 0
-// pmove_state_t is the information necessary for client side movement
-// prediction
-typedef enum {
-    // can accelerate and turn
-    PM_NORMAL,
-    PM_SPECTATOR,
-    // no acceleration or turning
-    PM_DEAD,
-    PM_GIB,     // different bounding box
-    PM_FREEZE
-} pmtype_t;
-
-// pmove->pm_flags
-#define PMF_DUCKED          BIT(0)
-#define PMF_JUMP_HELD       BIT(1)
-#define PMF_ON_GROUND       BIT(2)
-#define PMF_TIME_WATERJUMP  BIT(3)      // pm_time is waterjump
-#define PMF_TIME_LAND       BIT(4)      // pm_time is time before rejump
-#define PMF_TIME_TELEPORT   BIT(5)      // pm_time is non-moving time
-#define PMF_NO_PREDICTION   BIT(6)      // temporarily disables prediction (used for grappling hook)
-#define PMF_TELEPORT_BIT    BIT(7)      // used by Q2PRO (non-extended servers)
-#endif
-
-typedef struct {
-    pmtype_t    pm_type;
-
-    short       origin[3];      // 12.3
-    short       velocity[3];    // 12.3
-    byte        pm_flags;       // ducked, jump_held, etc
-    byte        pm_time;        // each unit = 8 ms
-    short       gravity;
-    short       delta_angles[3];    // add to command angles to get view direction
-                                    // changed by spawns, rotating objects, and teleporters
-} game3_pmove_state_t;
-
 #define MAX_STATS_GAME3 32
 
 typedef struct {
@@ -146,52 +106,6 @@ struct game3_edict_s {
     // the game dll can add anything it wants after
     // this point in the structure
 };
-
-typedef struct {
-    qboolean    allsolid;   // if true, plane is not valid
-    qboolean    startsolid; // if true, the initial point was in a solid area
-    float       fraction;   // time completed, 1.0 = didn't hit anything
-    vec3_t      endpos;     // final position
-    cplane_t    plane;      // surface normal at impact
-    csurface_t  *surface;   // surface hit
-    int         contents;   // contents on other side of surface hit
-    game3_edict_t  *ent;    // not set by CM_*() functions
-} game3_trace_t;
-
-typedef struct game3_usercmd_s {
-    byte    msec;
-    byte    buttons;
-    short   angles[3];
-    short   forwardmove, sidemove, upmove;
-    byte    impulse;        // remove?
-    byte    lightlevel;     // light level the player is standing on
-} game3_usercmd_t;
-
-typedef struct {
-    // state (in / out)
-    game3_pmove_state_t s;
-
-    // command (in)
-    game3_usercmd_t cmd;
-    qboolean        snapinitial;    // if s has been changed outside pmove
-
-    // results (out)
-    int         numtouch;
-    game3_edict_t  *touchents[MAXTOUCH];
-
-    vec3_t      viewangles;         // clamped
-    float       viewheight;
-
-    vec3_t      mins, maxs;         // bounding box size
-
-    game3_edict_t  *groundentity;
-    int         watertype;
-    int         waterlevel;
-
-    // callbacks to test the world
-    game3_trace_t (* q_gameabi trace)(const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end);
-    int         (*pointcontents)(const vec3_t point);
-} game3_pmove_t;
 
 //===============================================================
 

--- a/src/server/game3_proxy/game3_pmove.c
+++ b/src/server/game3_proxy/game3_pmove.c
@@ -500,7 +500,7 @@ static void PM_AirMove(void)
 //
 // clamp to server defined max speed
 //
-    maxspeed = (pm->s.pm_flags & PMF_DUCKED) ? pm_duckspeed : pmp->maxspeed;
+    maxspeed = (pm->s.pm_flags & G3PMF_DUCKED) ? pm_duckspeed : pmp->maxspeed;
 
     if (wishspeed > maxspeed) {
         VectorScale(wishvel, maxspeed / wishspeed, wishvel);
@@ -570,7 +570,7 @@ static void PM_CategorizePosition(void)
     point[1] = pml.origin[1];
     point[2] = pml.origin[2] - 0.25f;
     if (pml.velocity[2] > 180) { //!!ZOID changed from 100 to 180 (ramp accel)
-        pm->s.pm_flags &= ~PMF_ON_GROUND;
+        pm->s.pm_flags &= ~G3PMF_ON_GROUND;
         pm->groundentity = NULL;
     } else {
         trace = pm->trace(pml.origin, pm->mins, pm->maxs, point);
@@ -580,22 +580,22 @@ static void PM_CategorizePosition(void)
 
         if (!trace.ent || (trace.plane.normal[2] < 0.7f && !trace.startsolid)) {
             pm->groundentity = NULL;
-            pm->s.pm_flags &= ~PMF_ON_GROUND;
+            pm->s.pm_flags &= ~G3PMF_ON_GROUND;
         } else {
             pm->groundentity = trace.ent;
 
             // hitting solid ground will end a waterjump
-            if (pm->s.pm_flags & PMF_TIME_WATERJUMP) {
-                pm->s.pm_flags &= ~(PMF_TIME_WATERJUMP | PMF_TIME_LAND | PMF_TIME_TELEPORT);
+            if (pm->s.pm_flags & G3PMF_TIME_WATERJUMP) {
+                pm->s.pm_flags &= ~(G3PMF_TIME_WATERJUMP | G3PMF_TIME_LAND | G3PMF_TIME_TELEPORT);
                 pm->s.pm_time = 0;
             }
 
-            if (!(pm->s.pm_flags & PMF_ON_GROUND)) {
+            if (!(pm->s.pm_flags & G3PMF_ON_GROUND)) {
                 // just hit the ground
-                pm->s.pm_flags |= PMF_ON_GROUND;
+                pm->s.pm_flags |= G3PMF_ON_GROUND;
                 // don't do landing time if we were just going down a slope
                 if (pml.velocity[2] < -200 && !pmp->strafehack) {
-                    pm->s.pm_flags |= PMF_TIME_LAND;
+                    pm->s.pm_flags |= G3PMF_TIME_LAND;
                     // don't allow another jump for a little while
                     if (pml.velocity[2] < -400)
                         pm->s.pm_time = 25;
@@ -645,19 +645,19 @@ PM_CheckJump
 */
 static void PM_CheckJump(void)
 {
-    if (pm->s.pm_flags & PMF_TIME_LAND) {
+    if (pm->s.pm_flags & G3PMF_TIME_LAND) {
         // hasn't been long enough since landing to jump again
         return;
     }
 
     if (pm->cmd.upmove < 10) {
         // not holding jump
-        pm->s.pm_flags &= ~PMF_JUMP_HELD;
+        pm->s.pm_flags &= ~G3PMF_JUMP_HELD;
         return;
     }
 
     // must wait for jump to be released
-    if (pm->s.pm_flags & PMF_JUMP_HELD)
+    if (pm->s.pm_flags & G3PMF_JUMP_HELD)
         return;
 
     if (pm->s.pm_type == G3PM_DEAD)
@@ -687,10 +687,10 @@ static void PM_CheckJump(void)
     if (pm->groundentity == NULL)
         return;     // in air, so no effect
 
-    pm->s.pm_flags |= PMF_JUMP_HELD;
+    pm->s.pm_flags |= G3PMF_JUMP_HELD;
 
     pm->groundentity = NULL;
-    pm->s.pm_flags &= ~PMF_ON_GROUND;
+    pm->s.pm_flags &= ~G3PMF_ON_GROUND;
     pml.velocity[2] += 270;
     if (pml.velocity[2] < 270)
         pml.velocity[2] = 270;
@@ -742,7 +742,7 @@ static void PM_CheckSpecialMovement(void)
     VectorScale(flatforward, 50, pml.velocity);
     pml.velocity[2] = 350;
 
-    pm->s.pm_flags |= PMF_TIME_WATERJUMP;
+    pm->s.pm_flags |= G3PMF_TIME_WATERJUMP;
     pm->s.pm_time = 255;
 }
 
@@ -851,22 +851,22 @@ static void PM_CheckDuck(void)
     pm->mins[2] = -24;
 
     if (pm->s.pm_type == G3PM_DEAD) {
-        pm->s.pm_flags |= PMF_DUCKED;
-    } else if (pm->cmd.upmove < 0 && (pm->s.pm_flags & PMF_ON_GROUND)) {
+        pm->s.pm_flags |= G3PMF_DUCKED;
+    } else if (pm->cmd.upmove < 0 && (pm->s.pm_flags & G3PMF_ON_GROUND)) {
         // duck
-        pm->s.pm_flags |= PMF_DUCKED;
+        pm->s.pm_flags |= G3PMF_DUCKED;
     } else {
         // stand up if possible
-        if (pm->s.pm_flags & PMF_DUCKED) {
+        if (pm->s.pm_flags & G3PMF_DUCKED) {
             // try to stand up
             pm->maxs[2] = 32;
             trace = pm->trace(pml.origin, pm->mins, pm->maxs, pml.origin);
             if (!trace.allsolid)
-                pm->s.pm_flags &= ~PMF_DUCKED;
+                pm->s.pm_flags &= ~G3PMF_DUCKED;
         }
     }
 
-    if (pm->s.pm_flags & PMF_DUCKED) {
+    if (pm->s.pm_flags & G3PMF_DUCKED) {
         pm->maxs[2] = 4;
         pm->viewheight = -2;
     } else {
@@ -1002,7 +1002,7 @@ static void PM_ClampAngles(void)
     short   temp;
     int     i;
 
-    if (pm->s.pm_flags & PMF_TIME_TELEPORT) {
+    if (pm->s.pm_flags & G3PMF_TIME_TELEPORT) {
         pm->viewangles[YAW] = SHORT2ANGLE(pm->cmd.angles[YAW] + pm->s.delta_angles[YAW]);
         pm->viewangles[PITCH] = 0;
         pm->viewangles[ROLL] = 0;
@@ -1091,20 +1091,20 @@ void game3_Pmove(game3_pmove_t *pmove, pmoveParams_t *params)
         if (!msec)
             msec = 1;
         if (msec >= pm->s.pm_time) {
-            pm->s.pm_flags &= ~(PMF_TIME_WATERJUMP | PMF_TIME_LAND | PMF_TIME_TELEPORT);
+            pm->s.pm_flags &= ~(G3PMF_TIME_WATERJUMP | G3PMF_TIME_LAND | G3PMF_TIME_TELEPORT);
             pm->s.pm_time = 0;
         } else
             pm->s.pm_time -= msec;
     }
 
-    if (pm->s.pm_flags & PMF_TIME_TELEPORT) {
+    if (pm->s.pm_flags & G3PMF_TIME_TELEPORT) {
         // teleport pause stays exactly in place
-    } else if (pm->s.pm_flags & PMF_TIME_WATERJUMP) {
+    } else if (pm->s.pm_flags & G3PMF_TIME_WATERJUMP) {
         // waterjump has no control, but falls
         pml.velocity[2] -= pm->s.gravity * pml.frametime;
         if (pml.velocity[2] < 0) {
             // cancel as soon as we are falling down again
-            pm->s.pm_flags &= ~(PMF_TIME_WATERJUMP | PMF_TIME_LAND | PMF_TIME_TELEPORT);
+            pm->s.pm_flags &= ~(G3PMF_TIME_WATERJUMP | G3PMF_TIME_LAND | G3PMF_TIME_TELEPORT);
             pm->s.pm_time = 0;
         }
 

--- a/src/server/game3_proxy/game3_pmove.c
+++ b/src/server/game3_proxy/game3_pmove.c
@@ -17,9 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "shared/shared.h"
-#include "../server.h"
 #include "common/pmove.h"
-#include "game3.h"
+#include "common/game3_shared.h"
 #include "game3_pmove.h"
 
 #define STEPSIZE    18

--- a/src/server/game3_proxy/game3_pmove.c
+++ b/src/server/game3_proxy/game3_pmove.c
@@ -660,7 +660,7 @@ static void PM_CheckJump(void)
     if (pm->s.pm_flags & PMF_JUMP_HELD)
         return;
 
-    if (pm->s.pm_type == PM_DEAD)
+    if (pm->s.pm_type == G3PM_DEAD)
         return;
 
     if (pm->waterlevel >= 2) {
@@ -841,7 +841,7 @@ static void PM_CheckDuck(void)
     pm->maxs[0] = 16;
     pm->maxs[1] = 16;
 
-    if (pm->s.pm_type == PM_GIB) {
+    if (pm->s.pm_type == G3PM_GIB) {
         pm->mins[2] = 0;
         pm->maxs[2] = 16;
         pm->viewheight = 8;
@@ -850,7 +850,7 @@ static void PM_CheckDuck(void)
 
     pm->mins[2] = -24;
 
-    if (pm->s.pm_type == PM_DEAD) {
+    if (pm->s.pm_type == G3PM_DEAD) {
         pm->s.pm_flags |= PMF_DUCKED;
     } else if (pm->cmd.upmove < 0 && (pm->s.pm_flags & PMF_ON_GROUND)) {
         // duck
@@ -904,7 +904,7 @@ static bool PM_GoodPosition(void)
     vec3_t  origin, end;
     int     i;
 
-    if (pm->s.pm_type == PM_SPECTATOR)
+    if (pm->s.pm_type == G3PM_SPECTATOR)
         return true;
 
     for (i = 0; i < 3; i++)
@@ -1051,7 +1051,7 @@ void game3_Pmove(game3_pmove_t *pmove, pmoveParams_t *params)
 
     PM_ClampAngles();
 
-    if (pm->s.pm_type == PM_SPECTATOR) {
+    if (pm->s.pm_type == G3PM_SPECTATOR) {
         pml.frametime = pmp->speedmult * pm->cmd.msec * 0.001f;
         PM_FlyMove();
         PM_SnapPosition();
@@ -1060,13 +1060,13 @@ void game3_Pmove(game3_pmove_t *pmove, pmoveParams_t *params)
 
     pml.frametime = pm->cmd.msec * 0.001f;
 
-    if (pm->s.pm_type >= PM_DEAD) {
+    if (pm->s.pm_type >= G3PM_DEAD) {
         pm->cmd.forwardmove = 0;
         pm->cmd.sidemove = 0;
         pm->cmd.upmove = 0;
     }
 
-    if (pm->s.pm_type == PM_FREEZE)
+    if (pm->s.pm_type == G3PM_FREEZE)
         return;     // no movement at all
 
     // set mins, maxs, and viewheight
@@ -1078,7 +1078,7 @@ void game3_Pmove(game3_pmove_t *pmove, pmoveParams_t *params)
     // set groundentity, watertype, and waterlevel
     PM_CategorizePosition();
 
-    if (pm->s.pm_type == PM_DEAD)
+    if (pm->s.pm_type == G3PM_DEAD)
         PM_DeadMove();
 
     PM_CheckSpecialMovement();

--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -430,7 +430,7 @@ static void game_pmove_state_to_server(pmove_state_t* server_pmove_state, const 
     server_pmove_state->pm_type = pmtype_from_game3(game_pmove_state->pm_type);
     VectorScale(game_pmove_state->origin, 0.125f, server_pmove_state->origin);
     VectorScale(game_pmove_state->velocity, 0.125f, server_pmove_state->velocity);
-    server_pmove_state->pm_flags = game_pmove_state->pm_flags;
+    server_pmove_state->pm_flags = pmflags_from_game3(game_pmove_state->pm_flags);
     server_pmove_state->pm_time = game_pmove_state->pm_time * 8;
     server_pmove_state->gravity = game_pmove_state->gravity;
     server_pmove_state->delta_angles[0] = SHORT2ANGLE(game_pmove_state->delta_angles[0]);

--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -427,7 +427,7 @@ static void sync_edicts_server_to_game(void)
 
 static void game_pmove_state_to_server(pmove_state_t* server_pmove_state, const game3_pmove_state_t* game_pmove_state)
 {
-    server_pmove_state->pm_type = game_pmove_state->pm_type;
+    server_pmove_state->pm_type = pmtype_from_game3(game_pmove_state->pm_type);
     VectorScale(game_pmove_state->origin, 0.125f, server_pmove_state->origin);
     VectorScale(game_pmove_state->velocity, 0.125f, server_pmove_state->velocity);
     server_pmove_state->pm_flags = game_pmove_state->pm_flags;

--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "../server.h"
+#include "common/game3_shared.h"
 #include "game3_proxy.h"
 #include "game3.h"
 #include "game3_pmove.h"

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -952,7 +952,7 @@ static void init_pmove_and_es_flags(client_t *newcl)
     if (svs.csr.extended) {
         newcl->esFlags |= MSG_ES_EXTENSIONS;
     }
-    newcl->esFlags |= MSG_ES_FLOAT_COORDS;
+    newcl->esFlags |= MSG_ES_RERELEASE;
     newcl->pmp.waterhack = sv_waterjump_hack->integer >= 1;
 }
 


### PR DESCRIPTION
This set of changes allows connection to non-rerelease Q2PRO servers, with both the "standard" and "extended" games.

* Includes protocol compatibility fixed
* Deals with `PM_xxx` and `PMF_xxx` differences between rerelease and vanilla
* Use the built-in cgame only when connecting to "classic" servers
* Implement some functions missing in the built-in cgame