### PR TITLE
Transmit full button byte in rerelease protocol

### DIFF
--- a/inc/common/msg.h
+++ b/inc/common/msg.h
@@ -122,8 +122,8 @@ void    MSG_WriteFloat(float f);
 #if USE_CLIENT
 void    MSG_FlushBits(void);
 void    MSG_WriteBits(int value, int bits);
-int     MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int version);
-int     MSG_WriteDeltaUsercmd_Enhanced(const usercmd_t *from, const usercmd_t *cmd);
+int     MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int serverProtocol, int version);
+int     MSG_WriteDeltaUsercmd_Enhanced(const usercmd_t *from, const usercmd_t *cmd, int serverProtocol);
 #endif
 void    MSG_WriteDir(const vec3_t vector);
 void    MSG_PackEntity(entity_packed_t *out, const entity_state_t *in, bool ext);

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -850,9 +850,9 @@ typedef struct {
 //
 #define BUTTON_ATTACK   BIT(0)
 #define BUTTON_USE      BIT(1)
+#define BUTTON_HOLSTER  BIT(2) // Kex
 #define BUTTON_JUMP     BIT(3) // Kex
 #define BUTTON_CROUCH   BIT(4) // Kex
-#define BUTTON_HOLSTER  BIT(5) // Kex
 #define BUTTON_ANY      BIT(7) // any key whatsoever
 
 typedef uint8_t button_t;

--- a/src/client/input.c
+++ b/src/client/input.c
@@ -954,17 +954,17 @@ static void CL_SendDefaultCmd(void)
     // send this and the previous cmds in the message, so
     // if the last packet was dropped, it can be recovered
     cmd = &cl.cmds[(cl.cmdNumber - 2) & CMD_MASK];
-    MSG_WriteDeltaUsercmd(NULL, cmd, version);
+    MSG_WriteDeltaUsercmd(NULL, cmd, cls.serverProtocol, version);
     MSG_WriteByte(cl.lightlevel);
     oldcmd = cmd;
 
     cmd = &cl.cmds[(cl.cmdNumber - 1) & CMD_MASK];
-    MSG_WriteDeltaUsercmd(oldcmd, cmd, version);
+    MSG_WriteDeltaUsercmd(oldcmd, cmd, cls.serverProtocol, version);
     MSG_WriteByte(cl.lightlevel);
     oldcmd = cmd;
 
     cmd = &cl.cmds[cl.cmdNumber & CMD_MASK];
-    MSG_WriteDeltaUsercmd(oldcmd, cmd, version);
+    MSG_WriteDeltaUsercmd(oldcmd, cmd, cls.serverProtocol, version);
     MSG_WriteByte(cl.lightlevel);
 
     if (cls.serverProtocol <= PROTOCOL_VERSION_DEFAULT) {
@@ -1066,7 +1066,7 @@ static void CL_SendBatchedCmd(void)
         for (j = oldest->cmdNumber + 1; j <= history->cmdNumber; j++) {
             cmd = &cl.cmds[j & CMD_MASK];
             totalMsec += cmd->msec;
-            bits = MSG_WriteDeltaUsercmd_Enhanced(oldcmd, cmd);
+            bits = MSG_WriteDeltaUsercmd_Enhanced(oldcmd, cmd, cls.serverProtocol);
 #if USE_DEBUG
             if (cl_showpackets->integer == 3) {
                 MSG_ShowDeltaUsercmdBits_Enhanced(bits);

--- a/src/common/msg.c
+++ b/src/common/msg.c
@@ -227,13 +227,14 @@ static inline void MSG_WriteAngle16(float f)
 
 #if USE_CLIENT
 
-static void compute_buttons_upmove(const usercmd_t *cmd, int *buttons, short *upmove)
+static void compute_buttons_upmove(int *buttons, short *upmove)
 {
-    *buttons = cmd->buttons & ~(BUTTON_CROUCH | BUTTON_JUMP);
+    int prev_buttons = *buttons;
+    *buttons = prev_buttons & ~(BUTTON_CROUCH | BUTTON_JUMP);
     *upmove = 0;
-    if (cmd->buttons & BUTTON_JUMP)
+    if (prev_buttons & BUTTON_JUMP)
         *upmove += 200; /* cl_upspeed */
-    if (cmd->buttons & BUTTON_CROUCH)
+    if (prev_buttons & BUTTON_CROUCH)
         *upmove -= 200; /* cl_upspeed */
 }
 
@@ -252,12 +253,16 @@ int MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int serve
         from = &nullUserCmd;
     }
 
-    int from_buttons;
-    short from_upmove;
-    compute_buttons_upmove(from, &from_buttons, &from_upmove);
-    int new_buttons;
-    short new_upmove;
-    compute_buttons_upmove(cmd, &new_buttons, &new_upmove);
+    bool is_rerelease = serverProtocol == PROTOCOL_VERSION_RERELEASE;
+
+    int from_buttons = from->buttons;
+    short from_upmove = 0;
+    int new_buttons = cmd->buttons;
+    short new_upmove = 0;
+    if (is_rerelease) {
+        compute_buttons_upmove(&from_buttons, &from_upmove);
+        compute_buttons_upmove(&new_buttons, &new_upmove);
+    }
 
 //
 // send the movement message
@@ -273,10 +278,11 @@ int MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int serve
         bits |= CM_FORWARD;
     if (cmd->sidemove != from->sidemove)
         bits |= CM_SIDE;
-    if (new_upmove != from_upmove)
-        bits |= CM_UP;
     if (new_buttons != from_buttons)
         bits |= CM_BUTTONS;
+    // The next one can only happen when is_rerelease == false
+    if (new_upmove != from_upmove)
+        bits |= CM_UP;
 
     MSG_WriteByte(bits);
 
@@ -324,7 +330,9 @@ int MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int serve
         }
     }
 
-    if (version < PROTOCOL_VERSION_R1Q2_UCMD && (bits & CM_BUTTONS))
+    /* For rerelease, we want to write the full 'buttons' byte,
+     * due to the new button bits that have been added. */
+    if ((version < PROTOCOL_VERSION_R1Q2_UCMD || is_rerelease) && (bits & CM_BUTTONS))
         MSG_WriteByte(cmd->buttons);
 
     MSG_WriteByte(cmd->msec);
@@ -398,12 +406,16 @@ int MSG_WriteDeltaUsercmd_Enhanced(const usercmd_t *from,
         from = &nullUserCmd;
     }
 
-    int from_buttons;
-    short from_upmove;
-    compute_buttons_upmove(from, &from_buttons, &from_upmove);
-    int new_buttons;
-    short new_upmove;
-    compute_buttons_upmove(cmd, &new_buttons, &new_upmove);
+    bool is_rerelease = serverProtocol == PROTOCOL_VERSION_RERELEASE;
+
+    int from_buttons = from->buttons;
+    short from_upmove = 0;
+    int new_buttons = cmd->buttons;
+    short new_upmove = 0;
+    if (!is_rerelease) {
+        compute_buttons_upmove(&from_buttons, &from_upmove);
+        compute_buttons_upmove(&new_buttons, &new_upmove);
+    }
 
 //
 // send the movement message
@@ -419,12 +431,13 @@ int MSG_WriteDeltaUsercmd_Enhanced(const usercmd_t *from,
         bits |= CM_FORWARD;
     if (cmd->sidemove != from->sidemove)
         bits |= CM_SIDE;
-    if (new_upmove != from_upmove)
-        bits |= CM_UP;
     if (new_buttons != from_buttons)
         bits |= CM_BUTTONS;
     if (cmd->msec != from->msec)
         bits |= CM_IMPULSE;
+    // The next one can only happen when is_rerelease == false
+    if (new_upmove != from_upmove)
+        bits |= CM_UP;
 
     if (!bits) {
         MSG_WriteBits(0, 1);
@@ -469,8 +482,13 @@ int MSG_WriteDeltaUsercmd_Enhanced(const usercmd_t *from,
     }
 
     if (bits & CM_BUTTONS) {
-        int buttons = (new_buttons & 3) | (new_buttons >> 5);
-        MSG_WriteBits(buttons, 3);
+        if (is_rerelease) {
+            // Write full button byte to account for new buttons
+            MSG_WriteBits(new_buttons, 8);
+        } else {
+            int buttons = (new_buttons & 3) | (new_buttons >> 5);
+            MSG_WriteBits(buttons, 3);
+        }
     }
     if (bits & CM_IMPULSE) {
         MSG_WriteBits(cmd->msec, 8);
@@ -1762,26 +1780,16 @@ void MSG_ReadDeltaUsercmd(const usercmd_t *from, usercmd_t *to)
         to->angles[2] = MSG_ReadAngle16();
 
 // read movement
-    int buttons = from ? from->buttons : 0;
     if (bits & CM_FORWARD)
         to->forwardmove = MSG_ReadShort();
     if (bits & CM_SIDE)
         to->sidemove = MSG_ReadShort();
-    if (bits & CM_UP) {
-        short upmove = MSG_ReadShort();
-        buttons &= ~(BUTTON_JUMP | BUTTON_CROUCH);
-        if (upmove > 0)
-            buttons |= BUTTON_JUMP;
-        else if (upmove < 0)
-            buttons |= BUTTON_CROUCH;
-    }
+    Q_assert((bits & CM_UP) == 0); // should not be set in rerelease protocol
 
 // read buttons
     if (bits & CM_BUTTONS) {
-        buttons &= (BUTTON_JUMP | BUTTON_CROUCH);
-        buttons |= MSG_ReadByte();
+        to->buttons = MSG_ReadByte();
     }
-    to->buttons = buttons;
 
     if (bits & CM_IMPULSE)
         MSG_ReadByte(); // skip impulse
@@ -1862,28 +1870,18 @@ void MSG_ReadDeltaUsercmd_Enhanced(const usercmd_t *from, usercmd_t *to)
     }
 
 // read movement
-    int buttons = from ? from->buttons : 0;
     if (bits & CM_FORWARD) {
         to->forwardmove = MSG_ReadBits(-10);
     }
     if (bits & CM_SIDE) {
         to->sidemove = MSG_ReadBits(-10);
     }
-    if (bits & CM_UP) {
-        short upmove = MSG_ReadBits(-10);
-        if (upmove > 0)
-            buttons |= BUTTON_JUMP;
-        else if (upmove < 0)
-            buttons |= BUTTON_CROUCH;
-    }
+    Q_assert((bits & CM_UP) == 0); // should not be set in rerelease protocol
 
 // read buttons
     if (bits & CM_BUTTONS) {
-        buttons &= ~BUTTON_MASK;
-        int net_buttons = MSG_ReadBits(3);
-        buttons |= (net_buttons & 3) | ((net_buttons & 4) << 5);
+        to->buttons = MSG_ReadBits(8);
     }
-    to->buttons = buttons;
 
 // read time to run command
     if (bits & CM_IMPULSE) {

--- a/src/common/msg.c
+++ b/src/common/msg.c
@@ -242,7 +242,7 @@ static void compute_buttons_upmove(const usercmd_t *cmd, int *buttons, short *up
 MSG_WriteDeltaUsercmd
 =============
 */
-int MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int version)
+int MSG_WriteDeltaUsercmd(const usercmd_t *from, const usercmd_t *cmd, int serverProtocol, int version)
 {
     int     bits, buttons;
 
@@ -387,7 +387,8 @@ MSG_WriteDeltaUsercmd_Enhanced
 =============
 */
 int MSG_WriteDeltaUsercmd_Enhanced(const usercmd_t *from,
-                                   const usercmd_t *cmd)
+                                   const usercmd_t *cmd,
+                                   int serverProtocol)
 {
     int     bits, delta;
 


### PR DESCRIPTION
Make use of the "rerelease" protocol and write out the full usercmd button instead of just a subset or stuffing jump or crouch into "upmove".
This now allows simultaneous jumping in crouching (for games that support it) as well as the "holster" button.