### PR TITLE
Increase configstring length limit

### DIFF
--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -74,10 +74,10 @@ char *Com_MakePrintable(const char *s);
 static inline size_t CS_SIZE(const cs_remap_t *csr, int cs)
 {
     if (cs >= CS_STATUSBAR && cs < csr->airaccel)
-        return MAX_QPATH * (csr->airaccel - cs);
+        return CS_MAX_STRING_LENGTH * (csr->airaccel - cs);
 
     if (cs >= csr->general && cs < csr->end)
-        return MAX_QPATH * (csr->end - cs);
+        return CS_MAX_STRING_LENGTH * (csr->end - cs);
 
-    return MAX_QPATH;
+    return CS_MAX_STRING_LENGTH;
 }

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -131,7 +131,8 @@ typedef enum {
     MULTICAST_PVS,
 } multicast_t;
 
-typedef char configstring_t[MAX_QPATH];
+#define CS_MAX_STRING_LENGTH 96
+typedef char configstring_t[CS_MAX_STRING_LENGTH];
 
 /*
 ==============================================================
@@ -1293,7 +1294,8 @@ typedef int16_t layout_flags_t;
 //
 // config strings are a general means of communication from
 // the server to all connected clients.
-// Each config string can be at most MAX_QPATH characters.
+// Each config string can be at most CS_MAX_STRING_LENGTH  characters
+// for rerelease game (was MAX_QPATH previously).
 //
 #define CS_NAME             0
 #define CS_CDTRACK          1

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -432,7 +432,7 @@ static void CL_Record_f(void)
         if (!*s)
             continue;
 
-        len = Q_strnlen(s, MAX_QPATH);
+        len = Q_strnlen(s, CS_MAX_STRING_LENGTH);
         if (msg_write.cursize + len + 4 > size) {
             if (!CL_WriteDemoMessage(&msg_write))
                 return;
@@ -489,7 +489,7 @@ static void resume_record(void)
 
             s = cl.configstrings[index];
 
-            len = Q_strnlen(s, MAX_QPATH);
+            len = Q_strnlen(s, CS_MAX_STRING_LENGTH);
             if (cls.demo.buffer.cursize + len + 4 > cls.demo.buffer.maxsize) {
                 if (!CL_WriteDemoMessage(&cls.demo.buffer))
                     return;
@@ -840,7 +840,7 @@ void CL_EmitDemoSnapshot(void)
         if (!strcmp(from, to))
             continue;
 
-        len = Q_strnlen(to, MAX_QPATH);
+        len = Q_strnlen(to, CS_MAX_STRING_LENGTH);
         MSG_WriteByte(svc_configstring);
         MSG_WriteShort(i);
         MSG_WriteData(to, len);

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -346,7 +346,7 @@ static void PF_configstring(int index, const char *val)
 
     // error out entirely if it exceedes array bounds
     len = strlen(val);
-    maxlen = (svs.csr.end - index) * MAX_QPATH;
+    maxlen = (svs.csr.end - index) * CS_MAX_STRING_LENGTH;
     if (len >= maxlen) {
         Com_Error(ERR_DROP,
                   "%s: index %d overflowed: %zu > %zu",

--- a/src/server/init.c
+++ b/src/server/init.c
@@ -147,7 +147,7 @@ void SV_SpawnServer(const mapcmd_t *cmd)
     set_frame_time();
 
     // save name for levels that don't set message
-    Q_strlcpy(sv.configstrings[CS_NAME], cmd->server, MAX_QPATH);
+    Q_strlcpy(sv.configstrings[CS_NAME], cmd->server, CS_MAX_STRING_LENGTH);
     Q_strlcpy(sv.name, cmd->server, sizeof(sv.name));
     Q_strlcpy(sv.mapcmd, cmd->buffer, sizeof(sv.mapcmd));
 
@@ -165,7 +165,7 @@ void SV_SpawnServer(const mapcmd_t *cmd)
         sprintf(sv.configstrings[svs.csr.mapchecksum], "%d", sv.cm.checksum);
 
         // set inline model names
-        Q_concat(sv.configstrings[svs.csr.models + 1], MAX_QPATH, "maps/", cmd->server, ".bsp");
+        Q_concat(sv.configstrings[svs.csr.models + 1], CS_MAX_STRING_LENGTH, "maps/", cmd->server, ".bsp");
         for (i = 1; i < sv.cm.cache->nummodels; i++) {
             sprintf(sv.configstrings[svs.csr.models + 1 + i], "*%d", i);
         }

--- a/src/server/mvd.c
+++ b/src/server/mvd.c
@@ -639,7 +639,7 @@ static void emit_gamestate(void)
         if (!string[0]) {
             continue;
         }
-        length = Q_strnlen(string, MAX_QPATH);
+        length = Q_strnlen(string, CS_MAX_STRING_LENGTH);
         MSG_WriteShort(i);
         MSG_WriteData(string, length);
         MSG_WriteByte(0);

--- a/src/server/mvd/client.c
+++ b/src/server/mvd/client.c
@@ -591,7 +591,7 @@ static void demo_emit_snapshot(mvd_t *mvd)
         if (!strcmp(from, to))
             continue;
 
-        len = Q_strnlen(to, MAX_QPATH);
+        len = Q_strnlen(to, CS_MAX_STRING_LENGTH);
         MSG_WriteByte(mvd_configstring);
         MSG_WriteShort(i);
         MSG_WriteData(to, len);
@@ -1907,7 +1907,7 @@ static void emit_gamestate(mvd_t *mvd)
         if (!*s)
             continue;
 
-        len = Q_strnlen(s, MAX_QPATH);
+        len = Q_strnlen(s, CS_MAX_STRING_LENGTH);
         MSG_WriteShort(i);
         MSG_WriteData(s, len);
         MSG_WriteByte(0);

--- a/src/server/mvd/parse.c
+++ b/src/server/mvd/parse.c
@@ -283,7 +283,7 @@ static void MVD_UnicastString(mvd_t *mvd, bool reliable, mvd_player_t *player)
         }
     }
     if (!cs) {
-        cs = MVD_Malloc(sizeof(*cs) + MAX_QPATH - 1);
+        cs = MVD_Malloc(sizeof(*cs) + CS_MAX_STRING_LENGTH - 1);
         cs->index = index;
         cs->next = player->configstrings;
         player->configstrings = cs;

--- a/src/server/user.c
+++ b/src/server/user.c
@@ -108,7 +108,7 @@ static void write_configstrings(void)
         if (!string[0]) {
             continue;
         }
-        length = Q_strnlen(string, MAX_QPATH);
+        length = Q_strnlen(string, CS_MAX_STRING_LENGTH);
 
         // check if this configstring will overflow
         maybe_flush_msg(length + 4);
@@ -167,7 +167,7 @@ static void write_configstring_stream(void)
         if (!string[0]) {
             continue;
         }
-        length = Q_strnlen(string, MAX_QPATH);
+        length = Q_strnlen(string, CS_MAX_STRING_LENGTH);
 
         // check if this configstring will overflow
         if (msg_write.cursize + length + 4 > msg_write.maxsize) {


### PR DESCRIPTION
I think "just" increasing the string length limit should actually be sufficient.
* The string length limit isn't really a"hard" part of the game ABI. Access happens through functions, an increased length works just like before.
* In some cases, the string length is ignored and data is written past a single slot (for eg `CS_STATUSBAR`) - but that should still work as before, it's just the available space suddenly got a bit larger.
