### PR TITLE
Cleanup extension structures

### DIFF
--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -560,16 +560,11 @@ typedef game_export_t *(*game_entry_t)(game_import_t *);
 typedef struct {
     uint32_t    apiversion;
     uint32_t    structsize;
-} game_import_ex_t;
-
-typedef struct {
-    uint32_t    apiversion;
-    uint32_t    structsize;
 
     void        (*RestartFilesystem)(void); // called when fs_restart is issued
 } game_export_ex_t;
 
-typedef const game_export_ex_t *(*game_entry_ex_t)(const game_import_ex_t *);
+typedef const game_export_ex_t *(*game_entry_ex_t)(const void *);
 
 //===============================================================
 

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -560,8 +560,6 @@ typedef game_export_t *(*game_entry_t)(game_import_t *);
 typedef struct {
     uint32_t    apiversion;
     uint32_t    structsize;
-
-    void        *(*TagRealloc)(void *ptr, size_t size);
 } game_import_ex_t;
 
 typedef struct {

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -542,29 +542,11 @@ typedef game_export_t *(*game_entry_t)(game_import_t *);
 
 //===============================================================
 
-/*
- * GetGameAPIEx() is guaranteed to be called after GetGameAPI() and before
- * ge->Init().
- *
- * Unlike GetGameAPI(), passed game_import_ex_t * is valid as long as game
- * library is loaded. Pointed to structure can be used directly without making
- * a copy of it. If copying is neccessary, no more than structsize bytes must
- * be copied.
- *
- * New fields can be safely added at the end of game_import_ex_t and
- * game_export_ex_t structures, provided GAME_API_VERSION_EX is also bumped.
- */
-
-#define GAME_API_VERSION_EX     -1
-
 typedef struct {
-    uint32_t    apiversion;
-    uint32_t    structsize;
+    int api_version;
 
-    void        (*RestartFilesystem)(void); // called when fs_restart is issued
-} game_export_ex_t;
-
-typedef const game_export_ex_t *(*game_entry_ex_t)(const void *);
+    void (*RestartFilesystem)(void); // called when fs_restart is issued
+} game_q2pro_restart_filesystem_t;
 
 //===============================================================
 

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -1017,8 +1017,6 @@ static void *PF_GetExtension(const char *name)
 static const game_import_ex_t game_import_ex = {
     .apiversion = GAME_API_VERSION_EX,
     .structsize = sizeof(game_import_ex),
-
-    .TagRealloc = PF_TagRealloc,
 };
 
 static void *game_library;

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -1014,11 +1014,6 @@ static void *PF_GetExtension(const char *name)
     return NULL;
 }
 
-static const game_import_ex_t game_import_ex = {
-    .apiversion = GAME_API_VERSION_EX,
-    .structsize = sizeof(game_import_ex),
-};
-
 static void *game_library;
 
 /*
@@ -1083,7 +1078,7 @@ void SV_InitGameProgs(void)
         svs.is_game_rerelease = false;
         if (ge->apiversion == 3) {
             Com_DPrintf("Detected version 3 game library, using proxy game\n");
-            ge = GetGame3Proxy(&import, &game_import_ex, entry, entry_ex);
+            ge = GetGame3Proxy(&import, entry, entry_ex);
         } else {
             Com_Error(ERR_DROP, "Game library is version %d, expected %d",
                       ge->apiversion, GAME_API_VERSION);
@@ -1094,7 +1089,7 @@ void SV_InitGameProgs(void)
     }
 
     if (entry_ex)
-        gex = entry_ex(&game_import_ex);
+        gex = entry_ex(NULL);
 
     // initialize
     /* Note: Those functions may already call configstring(). They also decide the features...

--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -35,7 +35,6 @@ static void sync_single_edict_game_to_server(int index);
 static void sync_edicts_game_to_server(void);
 
 static game_import_t game_import;
-static const game_import_ex_t *game_import_ex;
 
 static game3_export_t *game3_export;
 static const game3_export_ex_t *game3_export_ex;
@@ -913,10 +912,9 @@ static const game3_import_ex_t game3_import_ex = {
     .TagRealloc = PF_TagRealloc,
 };
 
-game_export_t *GetGame3Proxy(game_import_t *import, const game_import_ex_t *import_ex, void *game3_entry, void *game3_ex_entry)
+game_export_t *GetGame3Proxy(game_import_t *import, void *game3_entry, void *game3_ex_entry)
 {
     game_import = *import;
-    game_import_ex = import_ex;
 
     game3_import_t import3;
     game3_export_t *(*entry)(game3_import_t *) = game3_entry;

--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -40,6 +40,19 @@ static game3_export_t *game3_export;
 static const game3_export_ex_t *game3_export_ex;
 static game_export_t game_export;
 
+static void wrap_RestartFilesystem(void)
+{
+    game3_export_ex->RestartFilesystem();
+}
+
+const char *game_q2pro_restart_filesystem_ext = "q2pro:restart_filesystem";
+
+static const game_q2pro_restart_filesystem_t game_q2pro_restart_filesystem = {
+    .api_version = 1,
+
+    .RestartFilesystem = wrap_RestartFilesystem,
+};
+
 #define GAME_EDICT_NUM(n) ((game3_edict_t *)((byte *)game3_export->edicts + game3_export->edict_size*(n)))
 #define NUM_FOR_GAME_EDICT(e) ((int)(((byte *)(e) - (byte *)game3_export->edicts) / game3_export->edict_size))
 
@@ -868,6 +881,9 @@ static void wrap_Pmove_export(pmove_t *pmove)
 
 static void *wrap_GetExtension_export(const char *name)
 {
+    if (game3_export_ex && strcmp(name, game_q2pro_restart_filesystem_ext) == 0) {
+        return (void*)&game_q2pro_restart_filesystem;
+    }
     return NULL;
 }
 
@@ -976,6 +992,8 @@ game_export_t *GetGame3Proxy(game_import_t *import, void *game3_entry, void *gam
     game3_export = entry(&import3);
     if (game3_ex_entry)
         game3_export_ex = entry_ex(&game3_import_ex);
+    else
+        game3_export_ex = NULL;
 
     game_export.apiversion = GAME_API_VERSION;
     game_export.PreInit = wrap_PreInit;

--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -304,9 +304,12 @@ static void wrap_FreeTags(unsigned tag)
     game_import.FreeTags(tag);
 }
 
-static void *wrap_TagRealloc(void *ptr, size_t size)
+static void *PF_TagRealloc(void *ptr, size_t size)
 {
-    return game_import_ex->TagRealloc(ptr, size);
+    if (!ptr && size) {
+        Com_Error(ERR_DROP, "%s: untagged allocation not allowed", __func__);
+    }
+    return Z_Realloc(ptr, size);
 }
 
 static char* wrap_argv(int idx)
@@ -907,7 +910,7 @@ static const game3_import_ex_t game3_import_ex = {
     .inVIS = wrap_inVIS,
 
     .GetExtension = wrap_GetExtension_import,
-    .TagRealloc = wrap_TagRealloc,
+    .TagRealloc = PF_TagRealloc,
 };
 
 game_export_t *GetGame3Proxy(game_import_t *import, const game_import_ex_t *import_ex, void *game3_entry, void *game3_ex_entry)

--- a/src/server/game3_proxy/game3_proxy.h
+++ b/src/server/game3_proxy/game3_proxy.h
@@ -19,6 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef GAME3_PROXY_H_
 #define GAME3_PROXY_H_
 
-game_export_t *GetGame3Proxy(game_import_t *import, const game_import_ex_t *import_ex, void *game3_entry, void *game3_ex_entry);
+game_export_t *GetGame3Proxy(game_import_t *import, void *game3_entry, void *game3_ex_entry);
 
 #endif // GAME3_PROXY_H_

--- a/src/server/game3_proxy/game3_proxy.h
+++ b/src/server/game3_proxy/game3_proxy.h
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef GAME3_PROXY_H_
 #define GAME3_PROXY_H_
 
+extern const char *game_q2pro_restart_filesystem_ext;
+
 game_export_t *GetGame3Proxy(game_import_t *import, void *game3_entry, void *game3_ex_entry);
 
 #endif // GAME3_PROXY_H_

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -1967,8 +1967,8 @@ void SV_UserinfoChanged(client_t *cl)
 
 void SV_RestartFilesystem(void)
 {
-    if (gex && gex->RestartFilesystem)
-        gex->RestartFilesystem();
+    if (g_restart_fs && g_restart_fs->RestartFilesystem)
+        g_restart_fs->RestartFilesystem();
 }
 
 #if USE_SYSCON

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -749,7 +749,7 @@ void SV_WriteFrameToClient_Enhanced(client_t *client);
 // sv_game.c
 //
 extern const game_export_t      *ge;
-extern const game_export_ex_t   *gex;
+extern const game_q2pro_restart_filesystem_t *g_restart_fs;
 
 void SV_InitGameProgs(void);
 void SV_ShutdownGameProgs(void);


### PR DESCRIPTION
Q2PRO added GetGameAPIEx() as it's own way to provide extension functionality.
Move this mechanism to game3_proxy entirely, so game.h is now "pure rerelease".