### PR TITLE
Demo & MVD fixes

### DIFF
--- a/inc/common/protocol.h
+++ b/inc/common/protocol.h
@@ -53,6 +53,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PROTOCOL_VERSION_MVD_DEFAULT            2010    // r177
 #define PROTOCOL_VERSION_MVD_EXTENDED_LIMITS    2011    // r2894
 #define PROTOCOL_VERSION_MVD_CURRENT            2011    // r2894
+#define PROTOCOL_VERSION_MVD_RERELEASE          3038
 
 #define R1Q2_SUPPORTED(x) \
     ((x) >= PROTOCOL_VERSION_R1Q2_MINIMUM && \
@@ -63,8 +64,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
      (x) <= PROTOCOL_VERSION_Q2PRO_CURRENT)
 
 #define MVD_SUPPORTED(x) \
-    ((x) >= PROTOCOL_VERSION_MVD_MINIMUM && \
-     (x) <= PROTOCOL_VERSION_MVD_CURRENT)
+    (((x) >= PROTOCOL_VERSION_MVD_MINIMUM && \
+      (x) <= PROTOCOL_VERSION_MVD_CURRENT) \
+     || ((x) == PROTOCOL_VERSION_MVD_RERELEASE))
 
 #define VALIDATE_CLIENTNUM(csr, x) \
     ((x) >= -1 && (x) < (csr)->max_edicts - 1)

--- a/inc/common/protocol.h
+++ b/inc/common/protocol.h
@@ -30,7 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PROTOCOL_VERSION_Q2PRO      36
 #define PROTOCOL_VERSION_MVD        37 // not used for UDP connections
 #define PROTOCOL_VERSION_RERELEASE  1038
-#define PROTOCOL_VERSION_EXTENDED   3434
+#define PROTOCOL_VERSION_EXTENDED   3434  // used in demos
 
 #define PROTOCOL_VERSION_R1Q2_MINIMUM           1903    // b6377
 #define PROTOCOL_VERSION_R1Q2_UCMD              1904    // b7387

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -596,6 +596,7 @@ typedef struct client_static_s {
 
         player_packed_t     ps;
         entity_packed_t     entities[MAX_EDICTS];
+        msgPsFlags_t        psFlags;
         msgEsFlags_t        esFlags;    // for writing
 
         sizebuf_t       message;

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -1211,20 +1211,14 @@ demoInfo_t *CL_GetDemoInfo(const char *path, demoInfo_t *info)
         }
     } else {
         c = MSG_ReadByte();
-        if ((c & 128) != mvd_serverdata) {
+        if ((c & SVCMD_MASK) != mvd_serverdata) {
             goto fail;
         }
         if (MSG_ReadLong() != PROTOCOL_VERSION_MVD) {
             goto fail;
         }
-        if (c & 128)
-        {
-            uint8_t extra = MSG_ReadByte();
-            c &= ~128;
-
-            if (extra & MVF_EXTLIMITS) {
-                csr = &cs_remap_q2pro_new;
-            }
+        if (c & (MVF_EXTLIMITS << SVCMD_BITS)) {
+            csr = &cs_remap_q2pro_new;
         }
         MSG_ReadWord();
         MSG_ReadLong();

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -1264,13 +1264,16 @@ demoInfo_t *CL_GetDemoInfo(const char *path, demoInfo_t *info)
         if ((c & SVCMD_MASK) != mvd_serverdata) {
             goto fail;
         }
-        if (MSG_ReadLong() != PROTOCOL_VERSION_MVD) {
+        int mvd_protocol = MSG_ReadLong();
+        if (mvd_protocol != PROTOCOL_VERSION_MVD) {
             goto fail;
         }
         if (c & (MVF_EXTLIMITS << SVCMD_BITS)) {
             csr = &cs_remap_q2pro_new;
         }
-        MSG_ReadWord();
+        int protocol_version = MSG_ReadWord();
+        if (protocol_version == PROTOCOL_VERSION_MVD_RERELEASE)
+            csr = &cs_remap_rerelease;
         MSG_ReadLong();
         MSG_ReadString(NULL, 0);
         clientNum = MSG_ReadShort();

--- a/src/client/gtv.c
+++ b/src/client/gtv.c
@@ -51,6 +51,7 @@ static void build_gamestate(void)
     }
 
     // set protocol flags
+    cls.gtv.psFlags = MSG_PS_RERELEASE | MSG_PS_EXTENSIONS;
     cls.gtv.esFlags = MSG_ES_UMASK | MSG_ES_BEAMORIGIN;
     if (cl.csr.extended)
         cls.gtv.esFlags |= MSG_ES_LONGSOLID | MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS;

--- a/src/client/gtv.c
+++ b/src/client/gtv.c
@@ -69,7 +69,9 @@ static void emit_gamestate(void)
         flags |= MVF_EXTLIMITS;
     MSG_WriteByte(mvd_serverdata | (flags << SVCMD_BITS));
     MSG_WriteLong(PROTOCOL_VERSION_MVD);
-    if (cl.csr.extended)
+    if (cl.is_rerelease_game)
+        MSG_WriteShort(PROTOCOL_VERSION_MVD_RERELEASE);
+    else if (cl.csr.extended)
         MSG_WriteShort(PROTOCOL_VERSION_MVD_CURRENT);
     else
         MSG_WriteShort(PROTOCOL_VERSION_MVD_DEFAULT);

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -597,7 +597,9 @@ static void CL_ParseServerData(void)
                       cls.serverProtocol, protocol);
         }
         // BIG HACK to let demos from release work with the 3.0x patch!!!
-        if (protocol == PROTOCOL_VERSION_EXTENDED) {
+        if (protocol == PROTOCOL_VERSION_RERELEASE) {
+            // keep protocol as-is
+        } else if (protocol == PROTOCOL_VERSION_EXTENDED) {
             cl.csr = cs_remap_q2pro_new;
             protocol = PROTOCOL_VERSION_DEFAULT;
         } else if (protocol < PROTOCOL_VERSION_OLD || protocol > PROTOCOL_VERSION_DEFAULT) {
@@ -741,7 +743,11 @@ static void CL_ParseServerData(void)
         cl.psFlags |= MSG_PS_EXTENSIONS;
     }
 
-    cls.demo.esFlags = cl.csr.extended ? CL_ES_EXTENDED_MASK : 0;
+    if (cls.serverProtocol == PROTOCOL_VERSION_RERELEASE) {
+        cls.demo.esFlags = cl.esFlags;
+    } else {
+        cls.demo.esFlags = cl.csr.extended ? CL_ES_EXTENDED_MASK : 0;
+    }
 
     // Load cgame (after we know all the timings)
     CG_Load(cl.gamedir, cl.is_rerelease_game);

--- a/src/server/mvd.c
+++ b/src/server/mvd.c
@@ -611,16 +611,14 @@ static void emit_gamestate(void)
     // pack MVD stream flags into extra bits
     extra = 0;
     if (sv_mvd_nomsgs->integer && mvd.dummy) {
-        extra |= MVF_NOMSGS;
+        extra |= MVF_NOMSGS << SVCMD_BITS;
     }
     if (svs.csr.extended) {
-        extra |= MVF_EXTLIMITS;
+        extra |= MVF_EXTLIMITS << SVCMD_BITS;
     }
 
     // send the serverdata
-    MSG_WriteByte(mvd_serverdata | (extra ? 128 : 0));
-    if (extra)
-        MSG_WriteByte(extra);
+    MSG_WriteByte(mvd_serverdata | extra);
     MSG_WriteLong(PROTOCOL_VERSION_MVD);
     if (svs.csr.extended)
         MSG_WriteShort(PROTOCOL_VERSION_MVD_CURRENT);

--- a/src/server/mvd.c
+++ b/src/server/mvd.c
@@ -620,7 +620,9 @@ static void emit_gamestate(void)
     // send the serverdata
     MSG_WriteByte(mvd_serverdata | extra);
     MSG_WriteLong(PROTOCOL_VERSION_MVD);
-    if (svs.csr.extended)
+    if (svs.is_game_rerelease)
+        MSG_WriteShort(PROTOCOL_VERSION_MVD_RERELEASE);
+    else if (svs.csr.extended)
         MSG_WriteShort(PROTOCOL_VERSION_MVD_CURRENT);
     else
         MSG_WriteShort(PROTOCOL_VERSION_MVD_DEFAULT);
@@ -1280,9 +1282,7 @@ void SV_MvdStartSound(int entnum, int channel, int flags,
         extrabits |= 2;
     }
 
-    SZ_WriteByte(&mvd.datagram, mvd_sound | (extrabits ? 128 : 0));
-    if (extrabits)
-        SZ_WriteByte(&mvd.datagram, extrabits);
+    SZ_WriteByte(&mvd.datagram, mvd_sound | extrabits);
     SZ_WriteByte(&mvd.datagram, flags);
     if (flags & SND_INDEX16)
         SZ_WriteShort(&mvd.datagram, soundindex);
@@ -2130,6 +2130,10 @@ void SV_MvdPostInit(void)
     if (svs.csr.extended) {
         mvd.esFlags |= MSG_ES_LONGSOLID | MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS;
         mvd.psFlags |= MSG_PS_EXTENSIONS;
+    }
+    if (svs.is_game_rerelease) {
+        mvd.esFlags |= MSG_ES_LONGSOLID | MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS | MSG_ES_RERELEASE;
+        mvd.psFlags |= MSG_PS_EXTENSIONS | MSG_PS_RERELEASE;
     }
 }
 

--- a/src/server/mvd/client.c
+++ b/src/server/mvd/client.c
@@ -1888,12 +1888,10 @@ static void emit_gamestate(mvd_t *mvd)
     size_t      len;
 
     // pack MVD stream flags into extra bits
-    extra = mvd->flags;
+    extra = mvd->flags << SVCMD_BITS;
 
     // send the serverdata
-    MSG_WriteByte(mvd_serverdata | (extra ? 128 : 0));
-    if (extra)
-        MSG_WriteByte(extra);
+    MSG_WriteByte(mvd_serverdata | extra);
     MSG_WriteLong(PROTOCOL_VERSION_MVD);
     MSG_WriteLong(mvd->version);
     MSG_WriteLong(mvd->servercount);

--- a/src/server/mvd/parse.c
+++ b/src/server/mvd/parse.c
@@ -1069,9 +1069,8 @@ bool MVD_ParseMessage(mvd_t *mvd)
         }
 
         cmd = MSG_ReadByte();
-
-        if (cmd & 128)
-            extrabits = MSG_ReadByte();// PARIL TEMP
+        extrabits = cmd >> SVCMD_BITS;
+        cmd &= SVCMD_MASK;
 
         SHOWNET(1, "%3zu:%s\n", msg_read.readcount - 1, MVD_ServerCommandString(cmd));
 

--- a/src/server/mvd/parse.c
+++ b/src/server/mvd/parse.c
@@ -492,7 +492,7 @@ static void MVD_ParseSound(mvd_t *mvd, int extrabits)
 
     // prepare multicast message
     MSG_WriteByte(svc_sound);
-    MSG_WriteByte(flags | SND_POS);
+    MSG_WriteByte(flags | SND_POS | SND_ENT);
     if (flags & SND_INDEX16)
         MSG_WriteShort(index);
     else
@@ -506,7 +506,7 @@ static void MVD_ParseSound(mvd_t *mvd, int extrabits)
         MSG_WriteByte(offset);
 
     MSG_WriteShort(sendchan);
-    MSG_WritePos(origin, svs.csr.extended);
+    MSG_WritePos(origin, mvd->esFlags & MSG_ES_RERELEASE);
 
     leaf1 = NULL;
     if (!(extrabits & 1)) {
@@ -556,7 +556,7 @@ static void MVD_ParseSound(mvd_t *mvd, int extrabits)
         msg->attenuation = attenuation;
         msg->timeofs = offset;
         msg->sendchan = sendchan;
-        MSG_ReadPos(msg->pos, true);
+        VectorCopy(origin, msg->pos);
 
         List_Remove(&msg->entry);
         List_Append(&cl->msg_unreliable_list, &msg->entry);
@@ -914,11 +914,19 @@ static void MVD_ParseServerData(mvd_t *mvd, int extrabits)
     mvd->psFlags = 0;
     mvd->csr = &cs_remap_old;
 
-    if (mvd->version >= PROTOCOL_VERSION_MVD_EXTENDED_LIMITS && mvd->flags & MVF_EXTLIMITS) {
+    if (mvd->version == PROTOCOL_VERSION_MVD_RERELEASE) {
+        mvd->esFlags |= MSG_ES_LONGSOLID | MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS | MSG_ES_RERELEASE;
+        mvd->psFlags |= MSG_PS_EXTENSIONS | MSG_PS_RERELEASE;
+        mvd->csr = &cs_remap_rerelease;
+    } else if (mvd->version >= PROTOCOL_VERSION_MVD_EXTENDED_LIMITS && mvd->flags & MVF_EXTLIMITS) {
         mvd->esFlags |= MSG_ES_LONGSOLID | MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS;
         mvd->psFlags |= MSG_PS_EXTENSIONS;
         mvd->csr = &cs_remap_q2pro_new;
     }
+
+    /* HACKY: is_game_rerelease must match the value that was used on the server
+     * so matching CS limits are used */
+    svs.is_game_rerelease = mvd->version == PROTOCOL_VERSION_MVD_RERELEASE;
 
 #if 0
     // change gamedir unless playing a demo


### PR DESCRIPTION
Fixes so demo recording/playback and MVD recording/playback/connections work without producing protocol errors when using a rerelease game.

(Still not perfect, though - notably, the cgame isn't used.)