### PR TITLE
Weapon & carousel appearance tweaks

### DIFF
--- a/src/client/wheel.c
+++ b/src/client/wheel.c
@@ -130,11 +130,13 @@ void CL_Carousel_Draw(void)
 
         if (weap->ammo_index >= 0) {
             int count = cgame->GetWeaponWheelAmmoCount(&cl.frame.ps, weap->ammo_index);
-            color_t color = count <= weap->quantity_warn ? COLOR_RED : COLOR_WHITE;
+            color_t color;
+            if (count <= weap->quantity_warn)
+                color = selected ? COLOR_RGB(255, 83, 83) : COLOR_RED;
+            else
+                color = selected ? COLOR_RGB(255, 255, 83) : COLOR_WHITE;
 
-            R_SetScale(1.0f);
-            SCR_DrawString((carousel_x + 12) / scr.hud_scale, (carousel_y + 2) / scr.hud_scale, UI_DROPSHADOW | UI_CENTER, color, va("%i", count));
-            R_SetScale(scr.hud_scale);
+            SCR_DrawString(carousel_x + (CAROUSEL_ICON_SIZE / 2), carousel_y + CAROUSEL_ICON_SIZE + 2, UI_DROPSHADOW | UI_CENTER, color, va("%i", count));
         }
     }
 }

--- a/src/client/wheel.c
+++ b/src/client/wheel.c
@@ -317,15 +317,16 @@ static int get_wheel_draw_size(void)
      * transparent pixels, ignore those then calculating scaling */
     const int wheel_padding = 74;
     const int wheel_content_size = scr.wheel_size - wheel_padding;
+    int real_hud_height = scr.hud_height / scr.hud_scale;
     int wheel_draw_size;
-    if (wheel_content_size >= scr.hud_height) {
-        int wheel_size_div = (2 * wheel_content_size - 1) / scr.hud_height;
+    if (wheel_content_size >= real_hud_height) {
+        int wheel_size_div = (2 * wheel_content_size - 1) / real_hud_height;
         wheel_draw_size = scr.wheel_size / wheel_size_div;
     } else {
-        int wheel_size_mul = scr.hud_height / wheel_content_size;
+        int wheel_size_mul = real_hud_height / wheel_content_size;
         wheel_draw_size = scr.wheel_size * wheel_size_mul;
     }
-    return wheel_draw_size;
+    return wheel_draw_size * scr.hud_scale;
 }
 
 void CL_Wheel_Input(int x, int y)

--- a/src/client/wheel.c
+++ b/src/client/wheel.c
@@ -313,12 +313,16 @@ void CL_Wheel_Close(bool released)
 static int get_wheel_draw_size(void)
 {
     // Find an integer fraction (or multiple) of the original wheel size to choose draw size
+    /* The rerelease weapon wheel image (which we're using) has a 74 pixels padding of fully
+     * transparent pixels, ignore those then calculating scaling */
+    const int wheel_padding = 74;
+    const int wheel_content_size = scr.wheel_size - wheel_padding;
     int wheel_draw_size;
-    if (scr.wheel_size >= scr.hud_height) {
-        int wheel_size_div = (scr.wheel_size + scr.wheel_size - 1) / scr.hud_height;
+    if (wheel_content_size >= scr.hud_height) {
+        int wheel_size_div = (2 * wheel_content_size - 1) / scr.hud_height;
         wheel_draw_size = scr.wheel_size / wheel_size_div;
     } else {
-        int wheel_size_mul = scr.hud_height / scr.wheel_size;
+        int wheel_size_mul = scr.hud_height / wheel_content_size;
         wheel_draw_size = scr.wheel_size * wheel_size_mul;
     }
     return wheel_draw_size;

--- a/src/client/wheel.c
+++ b/src/client/wheel.c
@@ -22,13 +22,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /* Draw item/ammo count for carousel and weapons/items wheel.
  * Notably, the count should be drawn a bit smaller than usual
  * text, but never below 100% */
-static void draw_count(cvar_t *scale_cvar, int x, int y, float scale, int flags, color_t color, int value)
+static void draw_count(int x, int y, float scale, int flags, color_t color, int value)
 {
     // Compute an integer text scale factor
-    int scale_factor = ((1.f / scr.hud_scale) * scale_cvar->value * scale) + 0.5f;
+    int scale_factor = ((1.f / scr.hud_scale) * scale) + 0.5f;
     if (scale_factor < 1)
         scale_factor = 1;
 
+    // Scale manually, as SCR_DrawStringStretch() can't scale below 100%
     R_SetScale(1.f / scale_factor);
 
     float coord_scale = 1.f / (scale_factor * scr.hud_scale);
@@ -156,7 +157,7 @@ void CL_Carousel_Draw(void)
             else
                 color = selected ? COLOR_RGB(255, 255, 83) : COLOR_WHITE;
 
-            draw_count(wc_ammo_scale, carousel_x + (CAROUSEL_ICON_SIZE / 2), carousel_y + CAROUSEL_ICON_SIZE + 2, 1, UI_DROPSHADOW | UI_CENTER, color, count);
+            draw_count(carousel_x + (CAROUSEL_ICON_SIZE / 2), carousel_y + CAROUSEL_ICON_SIZE + 2, wc_ammo_scale->value, UI_DROPSHADOW | UI_CENTER, color, count);
         }
     }
 }
@@ -513,7 +514,7 @@ static void draw_wheel_slot(int slot_idx, int center_x, int center_y, int wheel_
 
     int min_count = slot->is_powerup ? 2 : 0;
     if (count != -1 && count >= min_count) {
-        draw_count(ww_ammo_scale, center_x + p[0] + size, center_y + p[1] + size, scale, UI_CENTER | UI_DROPSHADOW, COLOR_SETA_F(count_color, wheel_alpha), count);
+        draw_count(center_x + p[0] + size, center_y + p[1] + size, ww_ammo_scale->value * scale, UI_CENTER | UI_DROPSHADOW, COLOR_SETA_F(count_color, wheel_alpha), count);
     }
 
     // We may need it later

--- a/src/client/wheel.c
+++ b/src/client/wheel.c
@@ -511,7 +511,8 @@ static void draw_wheel_slot(int slot_idx, int center_x, int center_y, int wheel_
 
     color_t count_color = slot_count_color(selected, warn_low);
 
-    if (count != -1) {
+    int min_count = slot->is_powerup ? 2 : 0;
+    if (count != -1 && count >= min_count) {
         draw_count(ww_ammo_scale, center_x + p[0] + size, center_y + p[1] + size, scale, UI_CENTER | UI_DROPSHADOW, COLOR_SETA_F(count_color, wheel_alpha), count);
     }
 

--- a/src/client/wheel.c
+++ b/src/client/wheel.c
@@ -105,6 +105,7 @@ static void CL_Carousel_Open(void)
 }
 
 #define CAROUSEL_ICON_SIZE (24 + 2)
+#define CAROUSEL_PAD       2
 
 static void R_DrawStretchPicShadowAlpha(int x, int y, int w, int h, qhandle_t pic, int shadow_offset, float alpha)
 {
@@ -123,12 +124,12 @@ void CL_Carousel_Draw(void)
     if (cl.carousel.state != WHEEL_OPEN)
         return;
 
-    int carousel_w = cl.carousel.num_slots * CAROUSEL_ICON_SIZE;
+    int carousel_w = cl.carousel.num_slots * (CAROUSEL_ICON_SIZE + CAROUSEL_PAD);
     int center_x = scr.hud_width / 2;
     int carousel_x = center_x - (carousel_w / 2);
     int carousel_y = (int) (scr.hud_height * wc_screen_frac_y->value);
     
-    for (int i = 0; i < cl.carousel.num_slots; i++, carousel_x += CAROUSEL_ICON_SIZE) {
+    for (int i = 0; i < cl.carousel.num_slots; i++, carousel_x += CAROUSEL_ICON_SIZE + CAROUSEL_PAD) {
         bool selected = cl.carousel.selected == cl.carousel.slots[i].item_index;
         const cl_wheel_weapon_t *weap = &cl.wheel_data.weapons[cl.carousel.slots[i].data_id];
         const cl_wheel_icon_t *icons = &weap->icons;


### PR DESCRIPTION
Changes were motivated by having better readable counts in weapon/item wheels and carousel.

* Try to scale wheel to make most of the available pixels
* Don't scale down count labels on wheel entries
* Don't scale down count labels on carousel entries

Before:
![quake006](https://github.com/user-attachments/assets/e6c65797-38ed-41a1-afeb-9653ef178932)
![quake007](https://github.com/user-attachments/assets/b06ef299-ad81-4745-812c-a6bdb374b8bc)
![quake008](https://github.com/user-attachments/assets/0ba08923-69f0-4f45-a081-56167bfabbfd)

After:
![quake010](https://github.com/user-attachments/assets/956ae2f5-bd2c-4a9e-945d-7428a13c4ced)
![quake011](https://github.com/user-attachments/assets/acb018d8-a1af-4599-8029-6c6aa3451939)
![quake012](https://github.com/user-attachments/assets/bea2f8d9-a76d-4f07-93ef-8912869e6ee0)
