### PR TITLE
server: handle q2proto_server_read errors properly

### DIFF
--- a/src/server/user.c
+++ b/src/server/user.c
@@ -1455,6 +1455,12 @@ void SV_ExecuteClientMessage(client_t *client)
         if (err == Q2P_ERR_NO_MORE_INPUT)
             break;
 
+        // Handle protocol errors from q2proto
+        if (err != Q2P_ERR_SUCCESS) {
+            SV_DropClient(client, "bad client message");
+            break;
+        }
+
         // Handle batched userinfo deltas
         if (message.type != Q2P_CLC_USERINFO_DELTA && prevUserinfoUpdateCount != userinfoUpdateCount) {
             SV_UpdateUserinfo();

--- a/src/server/user.c
+++ b/src/server/user.c
@@ -1457,7 +1457,7 @@ void SV_ExecuteClientMessage(client_t *client)
 
         // Handle protocol errors from q2proto
         if (err != Q2P_ERR_SUCCESS) {
-            SV_DropClient(client, "bad client message");
+            SV_DropClient(client, va("bad client message (%s)", q2proto_error_string(err)));
             break;
         }
 


### PR DESCRIPTION
when q2proto was added in commit 0bfa9ac3, the error handling for
q2proto_server_read() was incomplete. the original MSG_ReadByte() code
properly handled unknown command bytes by dropping the client

but the q2proto version only checks for Q2P_ERR_NO_MORE_INPUT and
ignores all other errors like Q2P_ERR_BAD_COMMAND!

this fix properly handles all q2proto errors by dropping the client
with a descriptive error message

---

while i was testing things in my engine, i sent a custom packet from the client
to the server, which for weird reasons the server had no handling for, and it was
_not_ a fan