### PR TITLE
Translate ##P<n> chat tokens to player names from configstrings

### DIFF
--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -910,9 +910,67 @@ static void CL_CheckForIP(const char *s)
     }
 }
 
+/*
+ * Replace ##P<n> tokens with player names from configstrings.
+ * Per server game.c FIXME: "the client is supposed to translate ##P<n> to
+ * player names" (playerskins configstring format: "name\\skin\\dogtag").
+ */
+static void CL_TranslatePlayerNameTokens(char *s, size_t size)
+{
+    const char *src;
+    char *dst, out[MAX_STRING_CHARS];
+    int playernum, idx;
+    size_t space;
+
+    if (!size)
+        return;
+
+    /* Need valid connection for configstrings */
+    if (cls.state < ca_loading)
+        return;
+
+    src = s;
+    dst = out;
+    *out = 0;
+
+    while (*src) {
+        space = sizeof(out) - (size_t)(dst - out) - 1;
+        if (!space)
+            break;
+
+        if (src[0] == '#' && src[1] == '#' && src[2] == 'P' && Q_isdigit(src[3])) {
+            src += 3;
+            playernum = 0;
+            while (Q_isdigit(*src))
+                playernum = playernum * 10 + (*src++ - '0');
+
+            if (playernum < MAX_CLIENTS) {
+                idx = cl.csr.playerskins + playernum;
+                if ((unsigned)idx < cl.csr.end) {
+                    const char *cs = cl.configstrings[idx];
+                    const char *end = strchr(cs, '\\');
+                    size_t len = end ? (size_t)(end - cs) : strlen(cs);
+                    if (len > space)
+                        len = space;
+                    if (len > 0) {
+                        memcpy(dst, cs, len);
+                        dst += len;
+                    }
+                }
+            }
+            continue;
+        }
+        *dst++ = *src++;
+    }
+    *dst = '\0';
+    Q_strlcpy(s, out, size);
+}
+
 static void CL_HandlePrint(int level, char *s)
 {
     const char *fmt;
+
+    CL_TranslatePlayerNameTokens(s, MAX_STRING_CHARS);
 
     if (level != PRINT_CHAT) {
         if (cl.csr.extended) {

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -911,51 +911,39 @@ static void CL_CheckForIP(const char *s)
 }
 
 /*
- * Replace ##P<n> tokens with player names from configstrings.
- * Per server game.c FIXME: "the client is supposed to translate ##P<n> to
- * player names" (playerskins configstring format: "name\\skin\\dogtag").
+ * Replace ##P<n> tokens with player names from cl.clientinfo.
+ * Per server game.c: "the client is supposed to translate ##P<n> to
+ * player names". Only occurs for broadcast prints.
  */
 static void CL_TranslatePlayerNameTokens(char *s, size_t size)
 {
     const char *src;
     char *dst, out[MAX_STRING_CHARS];
-    int playernum, idx;
+    int playernum;
     size_t space;
-
-    if (!size)
-        return;
-
-    /* Need valid connection for configstrings */
-    if (cls.state < ca_loading)
-        return;
 
     src = s;
     dst = out;
-    *out = 0;
 
     while (*src) {
         space = sizeof(out) - (size_t)(dst - out) - 1;
         if (!space)
             break;
 
-        if (src[0] == '#' && src[1] == '#' && src[2] == 'P' && Q_isdigit(src[3])) {
+        if (!strncmp(src, "##P", 3) && Q_isdigit(src[3])) {
             src += 3;
             playernum = 0;
             while (Q_isdigit(*src))
                 playernum = playernum * 10 + (*src++ - '0');
 
             if (playernum < MAX_CLIENTS) {
-                idx = cl.csr.playerskins + playernum;
-                if ((unsigned)idx < cl.csr.end) {
-                    const char *cs = cl.configstrings[idx];
-                    const char *end = strchr(cs, '\\');
-                    size_t len = end ? (size_t)(end - cs) : strlen(cs);
-                    if (len > space)
-                        len = space;
-                    if (len > 0) {
-                        memcpy(dst, cs, len);
-                        dst += len;
-                    }
+                const char *name = cl.clientinfo[playernum].name;
+                size_t len = strlen(name);
+                if (len > space)
+                    len = space;
+                if (len > 0) {
+                    memcpy(dst, name, len);
+                    dst += len;
                 }
             }
             continue;

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -913,38 +913,30 @@ static void CL_CheckForIP(const char *s)
 /*
  * Replace ##P<n> tokens with player names from cl.clientinfo.
  * Per server game.c: "the client is supposed to translate ##P<n> to
- * player names". Only occurs for broadcast prints.
+ * player names".
  */
 static void CL_TranslatePlayerNameTokens(char *s, size_t size)
 {
-    const char *src;
-    char *dst, out[MAX_STRING_CHARS];
-    int playernum;
-    size_t space;
-
-    src = s;
-    dst = out;
+    char out[MAX_STRING_CHARS];
+    const char *src = s;
+    char *dst = out;
 
     while (*src) {
-        space = sizeof(out) - (size_t)(dst - out) - 1;
+        size_t space = sizeof(out) - (size_t)(dst - out) - 1;
         if (!space)
             break;
 
         if (!strncmp(src, "##P", 3) && Q_isdigit(src[3])) {
             src += 3;
-            playernum = 0;
+            int playernum = 0;
             while (Q_isdigit(*src))
                 playernum = playernum * 10 + (*src++ - '0');
 
             if (playernum < MAX_CLIENTS) {
                 const char *name = cl.clientinfo[playernum].name;
-                size_t len = strlen(name);
-                if (len > space)
-                    len = space;
-                if (len > 0) {
-                    memcpy(dst, name, len);
-                    dst += len;
-                }
+                size_t len = min(strlen(name), space);
+                memcpy(dst, name, len);
+                dst += len;
             }
             continue;
         }
@@ -958,6 +950,8 @@ static void CL_HandlePrint(int level, char *s)
 {
     const char *fmt;
 
+    /* Called here rather than CL_ParseLocPrint() because ##P tokens
+     * arrive via svc_print broadcast messages, not localized prints. */
     CL_TranslatePlayerNameTokens(s, MAX_STRING_CHARS);
 
     if (level != PRINT_CHAT) {


### PR DESCRIPTION
### Problem
Rerelease/KEX servers encode player names in chat and broadcast messages as `##P<n>` tokens, expecting the client to resolve them. Without client-side handling, these tokens are shown as raw strings (e.g., `##P0` instead of the real player name). This is most noticeable when connected to a dedicated server.

### Solution
Added client-side `CL_TranslatePlayerNameTokens` and called it from `CL_HandlePrint` to:
* **Resolve tokens:** Look up player names using `cl.csr.playerskins`.
* **Parse Format:** Extract the `netname` from the playerskins configstring format (`name\skin\dogtag`).
* **State Safety:** Exit early if `cls.state < ca_loading` to ensure `cl.csr` is valid (set by `svc_serverdata`).

### Verification
* `cl.csr.playerskins` matches `CS_PLAYERSKINS` in `shared.c`.
* `cl.csr` is set correctly for `PROTOCOL_VERSION_RERELEASE` and `PROTOCOL_VERSION_KEX` in `parse.c`.
* Verified the logic successfully translates tokens on Windows (MSVC 2022).