### PR TITLE
improve configstring handling on non-rerelease servers

### DIFF
--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -107,12 +107,12 @@ char *UTF8_TranslitString(const char *src);
 static inline size_t Com_ConfigstringSize(const cs_remap_t *csr, int cs)
 {
     if (cs >= CS_STATUSBAR && cs < csr->airaccel)
-        return CS_MAX_STRING_LENGTH * (csr->airaccel - cs);
+        return csr->configstring_size * (csr->airaccel - cs);
 
     if (cs >= csr->general && cs < csr->end)
-        return CS_MAX_STRING_LENGTH * (csr->end - cs);
+        return csr->configstring_size * (csr->end - cs);
 
-    return CS_MAX_STRING_LENGTH;
+    return csr->configstring_size;
 }
 
 typedef struct {

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -160,7 +160,9 @@ typedef enum {
 #if !defined(GAME3_INCLUDE)
 
 #define CS_MAX_STRING_LENGTH 96
+#define CS_MAX_STRING_LENGTH_OLD 64
 typedef char configstring_t[CS_MAX_STRING_LENGTH];
+typedef char* configstring_ptr_t;
 
 #endif // !defined(GAME3_INCLUDE)
 
@@ -1683,6 +1685,8 @@ typedef struct {
     uint16_t    gamestyle;
 
     uint16_t    end;
+
+    size_t      configstring_size;
 } cs_remap_t;
 
 extern const cs_remap_t     cs_remap_old;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -809,7 +809,6 @@ void CL_RegisterSounds(void);
 void CL_RegisterBspModels(void);
 void CL_RegisterVWepModels(void);
 void CL_PrepRefresh(void);
-void CL_Configstrings_init(void);
 void CL_UpdateConfigstring(int index);
 
 //

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -345,8 +345,10 @@ typedef struct {
     frametime_t frametime;
     float       frametime_inv;  // 1/frametime
 
-    configstring_t  baseconfigstrings[MAX_CONFIGSTRINGS];
-    configstring_t  configstrings[MAX_CONFIGSTRINGS];
+    configstring_t      baseconfigstrings[MAX_CONFIGSTRINGS];
+    configstring_ptr_t  configstrings[MAX_CONFIGSTRINGS];
+    char                configstring_mem[MAX_CONFIGSTRINGS * sizeof(configstring_t)];
+
     cs_remap_t      csr;
     q2proto_game_api_t game_api;
 
@@ -807,6 +809,7 @@ void CL_RegisterSounds(void);
 void CL_RegisterBspModels(void);
 void CL_RegisterVWepModels(void);
 void CL_PrepRefresh(void);
+void CL_Configstrings_init(void);
 void CL_UpdateConfigstring(int index);
 
 //

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -984,17 +984,17 @@ void CL_EmitDemoSnapshot(void)
 
     // configstrings
     for (i = 0; i < cl.csr.end; i++) {
-        from = cl.baseconfigstrings[i];
+        from = (char*)cl.baseconfigstrings + i * cl.csr.configstring_size;
         to = cl.configstrings[i];
 
-        if (!strcmp(from, to))
+        if (!strncmp(from, to, cl.csr.configstring_size))
             continue;
 
         char* string = cl.configstrings[i];
         q2proto_svc_configstring_t *cfgstr = &configstrings[gamestate.num_configstrings++];
         cfgstr->index = i;
         cfgstr->value.str = string;
-        cfgstr->value.len = Q_strnlen(string, CS_MAX_STRING_LENGTH);
+        cfgstr->value.len = Q_strnlen(string, cl.csr.configstring_size);
     }
 
     /* baselines, for more robustness
@@ -1101,7 +1101,7 @@ void CL_FirstDemoFrame(void)
     Com_DPrintf("[%d] first frame\n", cl.frame.number);
 
     // save base configstrings
-    memcpy(cl.baseconfigstrings, cl.configstrings, sizeof(cl.baseconfigstrings[0]) * cl.csr.end);
+    memcpy(cl.baseconfigstrings, cl.configstring_mem, sizeof cl.baseconfigstrings);
 
     // obtain file length and offset of the second frame
     len = FS_Length(cls.demo.playback);
@@ -1147,6 +1147,7 @@ static void CL_Seek_f(void)
     int64_t dest;
     bool byte_seek, back_seek;
     char *from, *to;
+    size_t maxlen;
 
     if (Cmd_Argc() < 2) {
         Com_Printf("Usage: %s [+-]<timespec|percent>[%%]\n", Cmd_Argv(0));
@@ -1246,14 +1247,17 @@ static void CL_Seek_f(void)
 
             // reset configstrings
             for (i = 0; i < cl.csr.end; i++) {
-                from = cl.baseconfigstrings[i];
+                from = (char*)cl.baseconfigstrings + i * cl.csr.configstring_size;
                 to = cl.configstrings[i];
 
-                if (!strcmp(from, to))
+                if (!strncmp(from, to, cl.csr.configstring_size))
                     continue;
 
                 Q_SetBit(cl.dcs, i);
-                strcpy(to, from);
+
+
+                maxlen = Com_ConfigstringSize(&cl.csr, i);
+                Q_strlcpy(to, from, maxlen);
             }
 
             SZ_InitRead(&msg_read, snap->data, snap->msglen);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -327,6 +327,18 @@ void CL_ClientCommand(const char *string)
 
 /*
 ===================
+CL_Configstrings_init
+
+precondition: csr has been set. Initializes the array of configstrings so that they point to the right place in memory.
+*/
+void CL_Configstrings_init(void) {
+    for (size_t i = 0; i < MAX_CONFIGSTRINGS; i++) {
+        cl.configstrings[i] = cl.configstring_mem + i * cl.csr.configstring_size;
+    }
+}
+
+/*
+===================
 CL_ForwardToServer
 
 adds the current command line as a clc_stringcmd to the client message.

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -327,18 +327,6 @@ void CL_ClientCommand(const char *string)
 
 /*
 ===================
-CL_Configstrings_init
-
-precondition: csr has been set. Initializes the array of configstrings so that they point to the right place in memory.
-*/
-void CL_Configstrings_init(void) {
-    for (size_t i = 0; i < MAX_CONFIGSTRINGS; i++) {
-        cl.configstrings[i] = cl.configstring_mem + i * cl.csr.configstring_size;
-    }
-}
-
-/*
-===================
 CL_ForwardToServer
 
 adds the current command line as a clc_stringcmd to the client message.

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -708,6 +708,15 @@ static void CL_ParseServerData(const q2proto_svc_serverdata_t *serverdata)
             cl.csr = cs_remap_rerelease;
         else if (cl.game_api >= Q2PROTO_GAME_Q2PRO_EXTENDED)
             cl.csr = cs_remap_q2pro_new;
+
+        /*
+         * az: hack. rerelease protocol forces all configstrings to be 96 characters long.
+         * setting this to the default in the given cs_remap (potentially 64) causes ParseConfigstring to
+         * overwrite the last 32 bytes of the previous index on the CS_GENERAL + 1/CS_STATUSBAR + 1 ranges.
+         * now this case is rare, it only happens if we're running a non-rerelease dll on repro.
+        */
+        cl.csr.configstring_size = CS_MAX_STRING_LENGTH;
+
         cl.psFlags |= MSG_PS_RERELEASE | MSG_PS_EXTENSIONS;
         if (cl.game_api == Q2PROTO_GAME_Q2PRO_EXTENDED_V2)
             cl.psFlags |= MSG_PS_EXTENSIONS_2;
@@ -762,6 +771,8 @@ static void CL_ParseServerData(const q2proto_svc_serverdata_t *serverdata)
     }
 
     cl.max_stats = (cl.game_api >= Q2PROTO_GAME_Q2PRO_EXTENDED_V2) ? MAX_STATS_NEW : MAX_STATS_OLD;
+
+    CL_Configstrings_init();
 
     // Load cgame (after we know all the timings)
     CG_Load(cl.gamedir, cl.game_api == Q2PROTO_GAME_RERELEASE);

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -94,6 +94,18 @@ static void apply_entity_delta(entity_state_t *to, int number, const q2proto_ent
         to->scale = delta_state->scale / 16.f;
 }
 
+/*
+===================
+CL_Configstrings_init
+
+precondition: csr has been set. Initializes the array of configstrings so that they point to the right place in memory.
+*/
+static void CL_Configstrings_init(void) {
+    for (size_t i = 0; i < MAX_CONFIGSTRINGS; i++) {
+        cl.configstrings[i] = cl.configstring_mem + i * cl.csr.configstring_size;
+    }
+}
+
 static void CL_ParseDeltaEntity(server_frame_t           *frame,
                                 int                      newnum,
                                 const entity_state_t     *old,

--- a/src/client/precache.c
+++ b/src/client/precache.c
@@ -651,17 +651,20 @@ void CL_PrepRefresh(void)
     CL_SetSky();
 
     // load wheel data
-    int n;
-    for (n = cl.csr.wheelweapons, i = 0; i < MAX_WHEEL_ITEMS * 3; i++, n++) {
-        if (*cl.configstrings[n]) {
-            CL_LoadWheelEntry(n, cl.configstrings[n]);
+    // az: doesn't make sense to access configstrings that don't exist
+    if (cl.csr.extended) {
+        int n;
+        for (n = cl.csr.wheelweapons, i = 0; i < MAX_WHEEL_ITEMS * 3; i++, n++) {
+            if (*cl.configstrings[n]) {
+                CL_LoadWheelEntry(n, cl.configstrings[n]);
+            }
         }
-    }
 
-    // load shadow lights
-    for (n = cl.csr.shadowlights, i = 0; i < MAX_SHADOW_LIGHTS; i++, n++) {
-        if (*cl.configstrings[n]) {
-            CS_LoadShadowLight(n, cl.configstrings[n]);
+        // load shadow lights
+        for (n = cl.csr.shadowlights, i = 0; i < MAX_SHADOW_LIGHTS; i++, n++) {
+            if (*cl.configstrings[n]) {
+                CS_LoadShadowLight(n, cl.configstrings[n]);
+            }
         }
     }
 

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -1482,7 +1482,9 @@ const cs_remap_t cs_remap_old = {
     .cdloopcount = -1,
     .gamestyle   = -1,
 
-    .end         = MAX_CONFIGSTRINGS_OLD
+    .end         = MAX_CONFIGSTRINGS_OLD,
+
+    .configstring_size = CS_MAX_STRING_LENGTH_OLD
 };
 
 const cs_remap_t cs_remap_rerelease = {
@@ -1513,7 +1515,9 @@ const cs_remap_t cs_remap_rerelease = {
     .cdloopcount = CS_CD_LOOP_COUNT,
     .gamestyle   = CS_GAME_STYLE,
 
-    .end         = MAX_CONFIGSTRINGS
+    .end         = MAX_CONFIGSTRINGS,
+
+    .configstring_size = CS_MAX_STRING_LENGTH
 };
 
 const cs_remap_t cs_remap_q2pro_new = {
@@ -1544,5 +1548,7 @@ const cs_remap_t cs_remap_q2pro_new = {
     .cdloopcount = -1,
     .gamestyle   = -1,
 
-    .end         = MAX_CONFIGSTRINGS_EX
+    .end         = MAX_CONFIGSTRINGS_EX,
+
+    .configstring_size = CS_MAX_STRING_LENGTH_OLD
 };


### PR DESCRIPTION
This commit fixes the problem of there being a gap between parts of CS_STATUSBAR on non-repro servers with a configstring size of 64 (thus the 96 length ends up zero-padding it and causing an incomplete parse of the layout string)

The approach here is that we use a union of configstring (repro, 96 byte configstrings) and configstring_old (64 byte configstrings). Depending on the server protocol (rerelease/other) it picks the corresponding space in memory by using configstring or configstring_old so that these discontinuities do not happen. now, given that the protocol can send 96 configstrings anyway, Com_ConfigstringSize is altered to handle whether we're dealing with 96 or 64 byte configstrings (though I preserve the old behavior I do not think it will be correct in all cases... maybe recording old protocol demos with q2repro could be borked.)

the testing is not particularly thorough: I ran a server with a non-rerelease dll (q2pro's), a repro server, and connected to q2pro protocol servers, and it seems to work correctly.

testing this commit also led me to an issue, but I'll talk about it separately, since I ran asan and it doesn't seem like any sort of memory corruption, since it didn't trigger asan at all. mostly, after joining an non repro server and then starting a repro server, there is a segfault in SV_AreaEdicts_r.

