### PR TITLE
allow chathud to persist, chathud menu, show remaster bindings

### DIFF
--- a/src/client/console.c
+++ b/src/client/console.c
@@ -456,10 +456,10 @@ void Con_Init(void)
     con_notifytime->changed(con_notifytime);
     con_notifylines = Cvar_Get("con_notifylines", "4", 0);
     con_clock = Cvar_Get("con_clock", "0", 0);
-    con_height = Cvar_Get("con_height", "0.5", 0);
+    con_height = Cvar_Get("con_height", "0.5", CVAR_ARCHIVE);
     con_speed = Cvar_Get("scr_conspeed", "3", 0);
-    con_alpha = Cvar_Get("con_alpha", "1", 0);
-    con_scale = Cvar_Get("con_scale", "0", 0);
+    con_alpha = Cvar_Get("con_alpha", "1", CVAR_ARCHIVE);
+    con_scale = Cvar_Get("con_scale", "0", CVAR_ARCHIVE);
     con_scale->changed = con_width_changed;
     con_font = Cvar_Get("con_font", "conchars", 0);
     con_font->changed = con_media_changed;

--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -1448,7 +1448,7 @@ void SCR_Init(void)
     scr_demobar = Cvar_Get("scr_demobar", "1", 0);
     scr_font = Cvar_Get("scr_font", "conchars", 0);
     scr_font->changed = scr_font_changed;
-    scr_scale = Cvar_Get("scr_scale", "0", 0);
+    scr_scale = Cvar_Get("scr_scale", "0", CVAR_ARCHIVE);
     scr_scale->changed = scr_scale_changed;
     scr_crosshair = Cvar_Get("crosshair", "3", CVAR_ARCHIVE);
     scr_crosshair->changed = scr_crosshair_changed;
@@ -1460,13 +1460,13 @@ void SCR_Init(void)
     scr_graphscale = Cvar_Get("graphscale", "1", 0);
     scr_graphshift = Cvar_Get("graphshift", "0", 0);
 
-    scr_chathud = Cvar_Get("scr_chathud", "0", 0);
-    scr_chathud_lines = Cvar_Get("scr_chathud_lines", "4", 0);
-    scr_chathud_time = Cvar_Get("scr_chathud_time", "0", 0);
+    scr_chathud = Cvar_Get("scr_chathud", "0", CVAR_ARCHIVE);
+    scr_chathud_lines = Cvar_Get("scr_chathud_lines", "4", CVAR_ARCHIVE);
+    scr_chathud_time = Cvar_Get("scr_chathud_time", "0", CVAR_ARCHIVE);
     scr_chathud_time->changed = cl_timeout_changed;
     scr_chathud_time->changed(scr_chathud_time);
-    scr_chathud_x = Cvar_Get("scr_chathud_x", "8", 0);
-    scr_chathud_y = Cvar_Get("scr_chathud_y", "-64", 0);
+    scr_chathud_x = Cvar_Get("scr_chathud_x", "8", CVAR_ARCHIVE);
+    scr_chathud_y = Cvar_Get("scr_chathud_y", "-64", CVAR_ARCHIVE);
 
     ch_health = Cvar_Get("ch_health", "0", 0);
     ch_health->changed = ch_color_changed;

--- a/src/client/ui/q2pro.menu
+++ b/src/client/ui/q2pro.menu
@@ -89,6 +89,33 @@ begin video
     values "rendering backend" gl_shaders legacy shaders
 end
 
+
+begin weapons
+    title "Weapon Bindings"
+    bind "blaster" "use Blaster"
+    bind "shotgun" "use Shotgun"
+    bind "super shotgun" "use Super Shotgun"
+    bind "machinegun" "use Machinegun"
+    bind "chaingun" "use Chaingun"
+    bind "grenade launcher" "use Grenade Launcher"
+    bind "rocket launcher" "use Rocket Launcher"
+    bind "hyperblaster" "use HyperBlaster"
+    bind "railgun" "use Railgun"
+    bind "bfg10k" "use BFG10K"
+    bind "grenades" "use Grenades"
+    blank
+    bind "grapple/chainfist" "use Grapple"
+    bind "etf rifle" "use ETF Rifle"
+    bind "trap" "use Trap"
+    bind "tesla" "use Tesla"
+    bind "prox launcher" "use Prox Launcher"
+    bind "plasma beam" "use Plasma Beam"
+    blank
+    bind "ionripper" "use Ionripper"
+    bind "phalanx" "use Phalanx"
+    bind "disruptor" "use Disruptor"
+end
+
 begin options
     //title "Options"
     banner m_banner_options
@@ -156,6 +183,14 @@ begin crosshair
     range "alpha channel" ch_alpha 0 1
 end
 
+begin chathud
+    title "Chat HUD"
+    values "use chat hud" scr_chathud "no" "yes" "only switchable"
+    range "chat hud x" scr_chathud_x -128 128 8
+    range "chat hud y" scr_chathud_y -128 128 8
+    range "max lines" scr_chathud_lines 4 8 1
+end
+
 begin screen
     title "Screen Setup"
     range "screen size" viewsize 40 100 10
@@ -163,11 +198,12 @@ begin screen
     values "demo bar" scr_demobar no yes verbose
     range "HUD opacity" scr_alpha 0 1
     range "console opacity" con_alpha 0 1
-    pairs "HUD scale" scr_scale auto 0 1x 1 2x 2 4x 4
-    pairs "console scale" con_scale auto 0 1x 1 2x 2 4x 4
-    pairs "menu scale" ui_scale auto 0 1x 1 2x 2 4x 4
+    pairs "HUD scale" scr_scale auto 0 1x 1 2x 2 3x 3 4x 4
+    pairs "console scale" con_scale auto 0 1x 1 2x 2 3x 3 4x 4
+    pairs "menu scale" ui_scale auto 0 1x 1 2x 2 3x 3 4x 4
     blank
     action --align "crosshair setup..." pushmenu crosshair
+    action --align "chat hud..." pushmenu chathud
 end
 
 begin downloads
@@ -355,6 +391,9 @@ begin keys
     bind "pause game" pause
     bind "scoreboard" score
     bind "chat" messagemode
+    bind "weapon wheel" +wheel
+    bind "item wheel" +wheel2
+    bind "holster" +holster
     blank
     action --align "legacy keys..." pushmenu legacykeys
 end
@@ -371,17 +410,3 @@ begin legacykeys
     bind "keyboard look" +klook
 end
 
-begin weapons
-    title "Weapon Bindings"
-    bind "blaster" "use Blaster"
-    bind "shotgun" "use Shotgun"
-    bind "super shotgun" "use Super Shotgun"
-    bind "machinegun" "use Machinegun"
-    bind "chaingun" "use Chaingun"
-    bind "grenade launcher" "use Grenade Launcher"
-    bind "rocket launcher" "use Rocket Launcher"
-    bind "hyperblaster" "use HyperBlaster"
-    bind "railgun" "use Railgun"
-    bind "bfg10k" "use BFG10K"
-    bind "grenades" "use Grenades"
-end


### PR DESCRIPTION
chathud is a useful feature in some mods, but it generally is expected to be used as part of an autoexec configuration (but we can do better!)

* archive chathud and some console variables
* add a chathud menu on screen setup
* add holster and wheel bindings
* add MP weapon bindings (addresses #122)
* add 3x scaling (addresses #149)