### PR TITLE
game3_proxy: apply q_gameabi to wrap_trace() definition

### DIFF
--- a/src/server/game3_proxy/game3_proxy.c
+++ b/src/server/game3_proxy/game3_proxy.c
@@ -301,7 +301,7 @@ static void server_trace_to_game(game3_trace_t *tr, const trace_t *str)
     tr->ent = translate_edict_to_game(str->ent);
 }
 
-static game3_trace_t wrap_trace(const vec3_t start, const vec3_t mins,
+static game3_trace_t q_gameabi wrap_trace(const vec3_t start, const vec3_t mins,
                                 const vec3_t maxs, const vec3_t end,
                                 game3_edict_t *passedict, int contentmask)
 {


### PR DESCRIPTION
Fixes https://github.com/Paril/q2repro/issues/160

This is compiler gated and should only apply if `USE_GAME_ABI_HACK` is set

Claude Code's lenghy explanation about the fix:

> game3_import_t.trace (game3.h) is declared with the q_gameabi attribute, but wrap_trace() itself - the function actually assigned to that field - was defined without it. q_gameabi expands to
> __attribute__((callee_pop_aggregate_return(0))) when -Dgame-abi-hack is enabled, and that attribute has to be on the function definition for GCC to emit the old (callee-pops) struct-return calling convention; declaring it only on the struct field type has no effect on wrap_traces own compiled body.
> 
> Without this, a classic (API v3) game module built by an old GCC that expects the callee to pop the hidden aggregate-return pointer gets a wrap_trace() compiled with the modern (caller-pops) convention instead. The stack drifts by 4 bytes after every gi.trace() call, and the next value read off it (e.g. trace.ent in the modules own physics code) is garbage, typically SIGSEGVing through a bogus entity->touch() shortly after.
> 
> Reproduced with q2admin-tsmod (https://github.com/tastyspleen/q2admin-tsmod) wrapping a 2014-built classic Rocket Arena 2 gamei386.real.so: SV_PushEntity crashed on the first trace-and-touch after a toss-physics push, tracing back to a corrupted trace.ent read out of wrap_traces own stack frame.
> 
> Note this is a per-module, not a global, fix: a 2017-built Xatrix gamei386.real.so from the same q2admin-tsmod wrapper needs the opposite (modern) convention and breaks if this patch is compiled in - two API v3 modules built with different GCC versions can disagree, and a single q2reproded binary can only pick one behavior for wrap_trace at a time. Worked around by building two separate binaries (game-abi-hack enabled/disabled) for the two modules; a real fix likely needs runtime detection or a per-game-directory option rather than a single compile-time flag.