### PR TITLE
Avoid duplicated function definition for USE_FPS

### DIFF
--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -1248,23 +1248,6 @@ static void CL_ParseLocPrint(const q2proto_svc_locprint_t *locprint)
 }
 
 
-#if USE_FPS
-static void set_server_fps(int value)
-{
-    cl.frametime = Com_ComputeFrametime(value);
-    cl.frametime_inv = cl.frametime.div * BASE_1_FRAMETIME;
-
-    // fix time delta
-    if (cls.state == ca_active) {
-        int delta = cl.frame.number - cl.servertime / cl.frametime.time;
-        cl.serverdelta = Q_align_down(delta, cl.frametime.div);
-    }
-
-    Com_DPrintf("client framediv=%d time=%d delta=%d\n",
-                cl.frametime.div, cl.servertime, cl.serverdelta);
-}
-#endif
-
 /*
 =====================
 CL_ParseServerMessage


### PR DESCRIPTION
Note: this PR is AI-assisted

`set_server_fps()` is defined twice in `src/client/parse.c`: unconditionally at
~546, and again under `#if USE_FPS` at ~1251. The bodies are identical, so
`-Dvariable-fps=true` fails to build (MSVC C2084 / GCC redefinition).

Removes the guarded copy. No-op at USE_FPS=0; builds and runs with it enabled.
