### PR TITLE
Fix repeated footstep/fall sounds with variable-fps + rerelease game

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -345,6 +345,13 @@ typedef struct {
     frametime_t frametime;
     float       frametime_inv;  // 1/frametime
 
+#if USE_FPS
+    // how many frames an entity event stays set for, which is the server's real
+    // framediv (see SV_PrepWorldFrame). kept separate from frametime.div because
+    // that is forced to 1 for the rerelease game
+    int         event_div;
+#endif
+
     configstring_t      baseconfigstrings[MAX_CONFIGSTRINGS];
     configstring_ptr_t  configstrings[MAX_CONFIGSTRINGS];
     char                configstring_mem[MAX_CONFIGSTRINGS * sizeof(configstring_t)];

--- a/src/client/entities.c
+++ b/src/client/entities.c
@@ -84,7 +84,7 @@ entity_update_old(centity_t *ent, const entity_state_t *state, const vec_t *orig
     // check for new event
     if (state->event != ent->current.event)
         ent->event_frame = cl.frame.number; // new
-    else if (cl.frame.number - ent->event_frame >= cl.frametime.div)
+    else if (cl.frame.number - ent->event_frame >= cl.event_div)
         ent->event_frame = cl.frame.number; // refreshed
     else
         event = 0; // duplicated

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -547,6 +547,10 @@ static void set_server_fps(int value)
 {
     cl.frametime = Com_ComputeFrametime(value);
     cl.frametime_inv = cl.frametime.div * BASE_1_FRAMETIME;
+#if USE_FPS
+    // save the real framediv, callers may override frametime.div
+    cl.event_div = cl.frametime.div;
+#endif
 
     // fix time delta
     if (cls.state == ca_active) {


### PR DESCRIPTION
With the rerelease game at `sv_fps 40`, every footstep and fall impact plays 3-4 times
~25 ms apart.

The server holds `edict->s.event` for `sv.frametime.div` ticks deliberately —
`SV_PrepWorldFrame()` only calls `ge->PrepFrame()` on `SV_FRAMESYNC` — so that clients on a
reduced update rate (`client->framediv`) cannot miss an event. The client is what collapses
the repeats, in `entity_update_old()`, using `cl.frametime.div` as the window. But
`CL_ParseServerData()` forces `cl.frametime.div = 1` for `Q2PROTO_GAME_RERELEASE` right
after `set_server_fps()`, leaving a window of one frame, so every repeat is dispatched.

Records the server's real framediv in `cl.event_div` and dedups against that, leaving
`cl.frametime.div` — and the lerp/animation behaviour it drives — at 1. All hunks are
`#if USE_FPS`-guarded, so no change when `variable-fps` is off.

Before/after captures: https://youtu.be/naH-PsBg3qA and https://youtu.be/F5nlVptJ0-I

Needs #162 to build with `-Dvariable-fps=true`.
